### PR TITLE
Fix Codex prompt dismissal in tmux windows layout

### DIFF
--- a/agent-manager/scripts/tmux_helper.py
+++ b/agent-manager/scripts/tmux_helper.py
@@ -383,12 +383,14 @@ def _is_codex_model_choice_prompt(output: str) -> bool:
 
 
 def _tmux_send_key(agent_id: str, key: str) -> bool:
-    """Send a tmux key name (e.g., 'Down') to a session."""
+    """Send a tmux key name (e.g., 'Down') to an agent pane (layout-safe)."""
     if not session_exists(agent_id):
         return False
-    session_name = f"{SESSION_PREFIX}{agent_id}"
+    target = _agent_pane_target(agent_id)
+    if not target:
+        return False
     result = subprocess.run(
-        ['tmux', 'send-keys', '-t', session_name, key],
+        ['tmux', 'send-keys', '-t', target, key],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
Closes #14\n\n- Send fallback tmux key presses (e.g. Down) to the agent pane target rather than the dedicated session name\n- Keeps Codex model-selection auto-dismiss working in both session and single-session/windows layouts\n