### PR TITLE
Docs: clarify .agent vs .claude skill install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,22 @@ cat ~/.claude/skills/agent-manager/SKILL.md
 # From your repository root (where `agents/` lives)
 cd your-project
 
-# If installed (project-local):
+# If installed (project-local; path varies by tool):
 python3 .agent/skills/agent-manager/scripts/main.py list
+# (or, if you use `.claude/skills/` instead of `.agent/skills/`)
+python3 .claude/skills/agent-manager/scripts/main.py list
 
 # If installed (global):
 python3 ~/.claude/skills/agent-manager/scripts/main.py list
+# (or, if you use `~/.agent/skills/` instead of `~/.claude/skills/`)
+python3 ~/.agent/skills/agent-manager/scripts/main.py list
 
 # Sanity check your setup
+# (use the same install path as above; replace `.agent/skills/` with `.claude/skills/` if needed)
 python3 .agent/skills/agent-manager/scripts/main.py doctor
 
 # Start / monitor / stop
+# (same note: replace `.agent/skills/` with `.claude/skills/` if needed)
 python3 .agent/skills/agent-manager/scripts/main.py start EMP_0001
 python3 .agent/skills/agent-manager/scripts/main.py monitor EMP_0001 --follow
 python3 .agent/skills/agent-manager/scripts/main.py stop EMP_0001

--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -12,9 +12,12 @@ Employee agent orchestration system for managing AI agents in tmux sessions. A s
 ## Quick Start
 
 ```bash
+# Project-local install path varies by tool. If `.agent/skills/` doesn't exist, try `.claude/skills/`.
 # List all agents
 python3 .agent/skills/agent-manager/scripts/main.py list
+python3 .claude/skills/agent-manager/scripts/main.py list
 
+# (use the same path you chose above for the remaining commands)
 # Start dev agent
 python3 .agent/skills/agent-manager/scripts/main.py start dev
 


### PR DESCRIPTION
Closes #20\n\nUpdates README + SKILL quick-start examples to mention both common install locations (\.agent/skills and \.claude/skills) and adds a short note about choosing the path that exists.