### PR TITLE
Tmux layouts: agent metadata can place panes

### DIFF
--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -65,6 +65,7 @@ You are the Dev Agent...
 - `launcher_args`: Arguments for launcher
 - `skills`: Array of skill names from `.agent/skills/` (optional, injected at start)
 - `schedules`: Array of scheduled jobs (optional, see Scheduling section)
+- `tmux`: Optional tmux layout metadata (layout + target pane)
 
 ### Tmux Sessions
 
@@ -73,6 +74,29 @@ Each agent runs in a dedicated tmux session (`agent-{name}`):
 - **Easy monitoring**: `tmux capture-pane -t agent-dev`
 - **Direct interaction**: `tmux attach -t agent-dev`
 - **Clean separation**: No process pollution
+
+### Optional: Tmux Layouts
+
+You can auto-create a tmux layout and launch the agent in a specific pane:
+
+```yaml
+tmux:
+  layout:
+    split: h
+    panes:
+      - {}
+      - split: v
+        panes:
+          - {}
+          - {}
+  target_pane: "1.1"
+```
+
+Notes:
+- `split`: `h` (left/right) or `v` (top/bottom). `horizontal`/`vertical` also work.
+- `target_pane`: dot-separated path of `0`/`1` indexes into the layout tree.
+  `0` = left/top, `1` = right/bottom. `"1.1"` means right -> bottom.
+- If `tmux.layout` is set, `tmux.target_pane` is required.
 
 ### Launcher Types
 

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -38,6 +38,7 @@ from tmux_helper import (
     list_sessions,
     session_exists,
     start_session,
+    start_session_with_layout,
     stop_session,
     capture_output,
     send_keys,
@@ -787,10 +788,35 @@ def cmd_start(args):
     elif mcp_config_json and did_provider_restore:
         print(f"ℹ️  Provider session restored; skipping MCP config injection")
 
-    # Start session
-    if not start_session(agent_id, command, layout=getattr(args, 'tmux_layout', 'sessions')):
-        print(f"❌ Failed to start agent '{agent_name}'")
+    tmux_config = agent_config.get('tmux') or {}
+    if tmux_config and not isinstance(tmux_config, dict):
+        print("❌ Invalid 'tmux' in agent config (expected a mapping)")
         return 1
+
+    tmux_layout_spec = tmux_config.get('layout') if tmux_config else None
+    tmux_target_path = tmux_config.get('target_pane') if tmux_config else None
+
+    if tmux_layout_spec is None and tmux_target_path is not None:
+        print("❌ tmux.target_pane requires tmux.layout")
+        return 1
+
+    # Start session
+    if tmux_layout_spec is not None:
+        try:
+            start_session_with_layout(
+                agent_id,
+                command,
+                layout_spec=tmux_layout_spec,
+                target_path=tmux_target_path,
+                session_layout=getattr(args, 'tmux_layout', 'sessions'),
+            )
+        except ValueError as e:
+            print(f"❌ {e}")
+            return 1
+    else:
+        if not start_session(agent_id, command, layout=getattr(args, 'tmux_layout', 'sessions')):
+            print(f"❌ Failed to start agent '{agent_name}'")
+            return 1
 
     session_info = get_session_info(agent_id) or {}
     session_name = session_info.get('session', f"agent-{agent_id}")

--- a/agent-manager/scripts/tmux_helper.py
+++ b/agent-manager/scripts/tmux_helper.py
@@ -9,7 +9,7 @@ import subprocess
 import time
 import re
 import os
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Any, Tuple
 
 
 # Session prefix for all agent sessions
@@ -216,6 +216,194 @@ def start_session(agent_id: str, command: str, *, layout: str = "sessions") -> b
     if ok:
         _set_agent_pane_title(agent_id)
     return ok
+
+
+_LAYOUT_SPLIT_ALIASES = {
+    'h': 'h',
+    'horizontal': 'h',
+    'v': 'v',
+    'vertical': 'v',
+}
+
+
+def _normalize_layout_node(node: Any, *, path: str = "tmux.layout") -> Optional[dict]:
+    """Normalize a nested layout spec into a canonical dict structure.
+
+    Leaves are represented as {} or null (both treated as a leaf pane).
+    """
+    if node is None or node == {}:
+        return None
+    if not isinstance(node, dict):
+        raise ValueError(f"Invalid {path}: expected a mapping")
+
+    allowed_keys = {'split', 'panes'}
+    extra_keys = set(node.keys()) - allowed_keys
+    if extra_keys:
+        extra = ", ".join(sorted(extra_keys))
+        raise ValueError(f"Invalid {path}: unexpected keys {extra}")
+
+    split = node.get('split')
+    panes = node.get('panes')
+    if split is None or panes is None:
+        raise ValueError(f"Invalid {path}: expected 'split' and 'panes'")
+    if not isinstance(split, str):
+        raise ValueError(f"Invalid {path}: 'split' must be a string")
+
+    split_key = _LAYOUT_SPLIT_ALIASES.get(split.strip().lower())
+    if split_key not in {'h', 'v'}:
+        raise ValueError(f"Invalid {path}: 'split' must be 'h' or 'v'")
+
+    if not isinstance(panes, list) or len(panes) != 2:
+        raise ValueError(f"Invalid {path}: 'panes' must be a list of 2 items")
+
+    return {
+        'split': split_key,
+        'panes': [
+            _normalize_layout_node(panes[0], path=f"{path}.panes[0]"),
+            _normalize_layout_node(panes[1], path=f"{path}.panes[1]"),
+        ],
+    }
+
+
+def _parse_target_path(value: Any) -> Tuple[int, ...]:
+    if value is None:
+        raise ValueError("tmux.target_pane is required when tmux.layout is set")
+    if isinstance(value, (int, bool)):
+        parts = [value]
+    elif isinstance(value, list):
+        parts = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return tuple()
+        parts = text.replace('/', '.').split('.')
+    else:
+        raise ValueError("tmux.target_pane must be a list or dot-separated string")
+
+    path: list[int] = []
+    for item in parts:
+        if isinstance(item, bool):
+            raise ValueError("tmux.target_pane entries must be 0 or 1")
+        try:
+            index = int(item)
+        except (TypeError, ValueError):
+            raise ValueError("tmux.target_pane entries must be 0 or 1")
+        if index not in (0, 1):
+            raise ValueError("tmux.target_pane entries must be 0 or 1")
+        path.append(index)
+    return tuple(path)
+
+
+def _resolve_pane_id(target: str) -> str:
+    result = subprocess.run(
+        ['tmux', 'display-message', '-p', '-t', target, '#{pane_id}'],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout).strip()
+        raise ValueError(f"Failed to resolve pane id for tmux target {target}: {error}")
+    pane_id = result.stdout.strip()
+    if not pane_id:
+        raise ValueError(f"Failed to resolve pane id for tmux target {target}")
+    return pane_id
+
+
+def _set_pane_title(pane_target: str, title: str) -> None:
+    subprocess.run(
+        ['tmux', 'select-pane', '-t', pane_target, '-T', title],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _split_pane(pane_id: str, split: str) -> str:
+    split_flag = '-h' if split == 'h' else '-v'
+    result = subprocess.run(
+        ['tmux', 'split-window', split_flag, '-d', '-t', pane_id, '-P', '-F', '#{pane_id}'],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout).strip()
+        raise ValueError(f"Failed to split pane {pane_id}: {error}")
+    new_pane_id = result.stdout.strip()
+    if not new_pane_id:
+        raise ValueError(f"Failed to resolve new pane id for {pane_id}")
+    return new_pane_id
+
+
+def _build_layout(
+    pane_id: str,
+    layout: Optional[dict],
+    *,
+    pane_map: Dict[Tuple[int, ...], str],
+    path: Tuple[int, ...] = (),
+) -> None:
+    if layout is None:
+        pane_map[path] = pane_id
+        return
+
+    new_pane_id = _split_pane(pane_id, layout['split'])
+    _build_layout(pane_id, layout['panes'][0], pane_map=pane_map, path=path + (0,))
+    _build_layout(new_pane_id, layout['panes'][1], pane_map=pane_map, path=path + (1,))
+
+
+def start_session_with_layout(
+    agent_id: str,
+    command: str,
+    *,
+    layout_spec: Any,
+    target_path: Any,
+    session_layout: str = "sessions",
+) -> str:
+    """Start an agent and place it into a specific pane within a generated layout.
+
+    This starts a placeholder shell first, creates the tmux split layout, then respawns the
+    configured target pane to run the real command.
+    """
+    layout = _normalize_layout_node(layout_spec)
+    if layout is None:
+        raise ValueError("tmux.layout must define at least one split")
+    target = _parse_target_path(target_path)
+
+    if not start_session(agent_id, "bash", layout=session_layout):
+        raise ValueError("Failed to start tmux container for agent")
+
+    try:
+        root_target = _agent_pane_target(agent_id)
+        if not root_target:
+            raise ValueError("Failed to resolve agent tmux target after startup")
+        root_pane_id = _resolve_pane_id(root_target)
+
+        pane_map: Dict[Tuple[int, ...], str] = {}
+        _build_layout(root_pane_id, layout, pane_map=pane_map)
+        if target not in pane_map:
+            raise ValueError(f"tmux.target_pane {target} does not match any leaf pane")
+
+        expected_title = _window_name_for_agent(agent_id)
+        for path, pane_id in pane_map.items():
+            if path == target:
+                _set_pane_title(pane_id, expected_title)
+            else:
+                suffix = ".".join(str(i) for i in path) if path else "root"
+                _set_pane_title(pane_id, f"{expected_title}:{suffix}")
+
+        target_pane = pane_map[target]
+        result = subprocess.run(
+            ['tmux', 'respawn-pane', '-k', '-t', target_pane, command],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            error = (result.stderr or result.stdout).strip()
+            raise ValueError(f"Failed to launch command in target pane: {error}")
+
+        subprocess.run(['tmux', 'select-pane', '-t', target_pane], capture_output=True, text=True)
+        return target_pane
+    except Exception:
+        stop_session(agent_id)
+        raise
 
 
 def stop_session(agent_id: str) -> bool:

--- a/examples/getting-started.md
+++ b/examples/getting-started.md
@@ -33,6 +33,23 @@ python3 .agent/skills/agent-manager/scripts/main.py list
 python3 .agent/skills/agent-manager/scripts/main.py start EMP_0001
 ```
 
+### Optional: auto tmux layout
+
+Add to your agent frontmatter to split panes and choose the target pane:
+
+```yaml
+tmux:
+  layout:
+    split: h
+    panes:
+      - {}
+      - split: v
+        panes:
+          - {}
+          - {}
+  target_pane: "1.1"
+```
+
 ## 4) Monitor output
 
 ```bash


### PR DESCRIPTION
Closes #22

Implements agent `tmux:` metadata to auto-create a tmux pane layout and start the agent inside the configured target pane.

- Adds `tmux.layout` + `tmux.target_pane` (+ optional `tmux.window`) support
- Stores the resolved tmux pane target so `monitor/send` continue to work
- Updates docs/examples

QA:
- `python3 -m py_compile agent-manager/scripts/main.py agent-manager/scripts/tmux_helper.py`
- Manual tmux smoke: layout created; target pane executed command; cleanup OK
