### PR TITLE
chore: clarify PyYAML dependency + add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+
+      - name: Compile
+        run: python -m compileall agent-manager/scripts
+
+      - name: Unit tests
+        run: python -m unittest discover -s agent-manager/scripts/tests -p 'test_*.py'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Managing multiple AI agents is deceptively complex:
 
 **Advantages:**
 
-- **Zero dependencies** beyond `tmux` + `python3`
+- **Minimal dependencies**: `tmux` + `python3` (+ `pyyaml` for parsing YAML frontmatter)
 - **Cross-platform** (where tmux runs)
 - **Cron-friendly**: `schedule sync` writes crontab entries calling the installed `main.py` by absolute path
 
@@ -135,7 +135,14 @@ See [agent-manager/SKILL.md](agent-manager/SKILL.md) for complete documentation.
 
 - Python 3.x
 - tmux
+- `pyyaml` (for parsing YAML frontmatter)
 - Agents defined under `agents/` (supports `agents/EMP_0001.md` and `agents/EMP_0001/AGENTS.md`)
+
+Install the Python dependency:
+
+```bash
+python3 -m pip install pyyaml
+```
 
 ## Codex Launcher Notes
 

--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -9,6 +9,16 @@ allowed-tools: [Read, Write, Edit, Bash, Task]
 
 Employee agent orchestration system for managing AI agents in tmux sessions. A simple, dependency-light alternative to CAO.
 
+## Dependencies
+
+- `tmux`
+- Python 3
+- `pyyaml` (required to parse YAML frontmatter)
+
+```bash
+python3 -m pip install pyyaml
+```
+
 ## Quick Start
 
 ```bash

--- a/agent-manager/scripts/agent_config.py
+++ b/agent-manager/scripts/agent_config.py
@@ -7,14 +7,43 @@ Supports two agent profile layouts under `agents/`:
 
 import os
 import re
-import yaml
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Iterable
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
 
 from repo_root import find_repo_root, get_repo_root, get_skill_search_dirs
 
 
 AGENT_DIR_PROFILE_FILENAME = "AGENTS.md"
+
+
+_PYYAML_REQUIRED = (
+    "PyYAML is required to parse YAML frontmatter. "
+    "Install it with: python3 -m pip install pyyaml"
+)
+
+
+def _require_yaml() -> None:
+    if yaml is None:
+        raise RuntimeError(_PYYAML_REQUIRED)
+
+
+def _yaml_safe_load(payload: str) -> dict:
+    _require_yaml()
+    assert yaml is not None
+    loaded = yaml.safe_load(payload) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError("Invalid YAML frontmatter: expected a mapping")
+    return loaded
+
+
+_YAML_PARSE_EXCEPTIONS = (ValueError,)
+if yaml is not None:  # pragma: no cover
+    _YAML_PARSE_EXCEPTIONS = (ValueError, yaml.YAMLError)
 
 
 def _file_id_from_profile_path(profile_path: Path) -> str:
@@ -73,7 +102,7 @@ def parse_agent_file(agent_path: Path) -> Dict[str, Any]:
     yaml_content = frontmatter_match.group(1)
     markdown_content = frontmatter_match.group(2)
 
-    config = yaml.safe_load(yaml_content) or {}
+    config = _yaml_safe_load(yaml_content)
     config['role_definition'] = markdown_content.strip()
 
     # Extract file ID from path (e.g., EMP_0001 from EMP_0001.md; EMP_0001 from EMP_0001/AGENTS.md)
@@ -181,7 +210,7 @@ def resolve_agent(name_or_id: str, agents_dir: Optional[Path] = None) -> Optiona
                 config = parse_agent_file(profile_path)
                 config['_file_path'] = profile_path
                 return expand_config_env_vars(config)
-            except (ValueError, yaml.YAMLError):
+            except _YAML_PARSE_EXCEPTIONS:
                 return None
 
     # 2) If it's a bare filename, try resolving it inside agents_dir.
@@ -194,7 +223,7 @@ def resolve_agent(name_or_id: str, agents_dir: Optional[Path] = None) -> Optiona
                 config = parse_agent_file(agent_file)
                 config['_file_path'] = agent_file
                 return expand_config_env_vars(config)
-            except (ValueError, yaml.YAMLError):
+            except _YAML_PARSE_EXCEPTIONS:
                 return None
 
     if agents_dir is None:
@@ -211,7 +240,7 @@ def resolve_agent(name_or_id: str, agents_dir: Optional[Path] = None) -> Optiona
                 # Add file path to config
                 config['_file_path'] = agent_file
                 return expand_config_env_vars(config)
-        except (ValueError, yaml.YAMLError):
+        except _YAML_PARSE_EXCEPTIONS:
             continue
 
     # Try by file ID
@@ -221,7 +250,7 @@ def resolve_agent(name_or_id: str, agents_dir: Optional[Path] = None) -> Optiona
             config = parse_agent_file(agent_file)
             config['_file_path'] = agent_file
             return expand_config_env_vars(config)
-        except (ValueError, yaml.YAMLError):
+        except _YAML_PARSE_EXCEPTIONS:
             return None
 
     agent_dir_profile = agents_dir / name_or_id / AGENT_DIR_PROFILE_FILENAME
@@ -230,7 +259,7 @@ def resolve_agent(name_or_id: str, agents_dir: Optional[Path] = None) -> Optiona
             config = parse_agent_file(agent_dir_profile)
             config['_file_path'] = agent_dir_profile
             return expand_config_env_vars(config)
-        except (ValueError, yaml.YAMLError):
+        except _YAML_PARSE_EXCEPTIONS:
             return None
 
     return None
@@ -262,7 +291,7 @@ def list_all_agents(agents_dir: Optional[Path] = None) -> Dict[str, Dict[str, An
             file_id = config.get('file_id')
             if file_id:
                 agents[file_id] = config
-        except (ValueError, yaml.YAMLError):
+        except _YAML_PARSE_EXCEPTIONS:
             continue
 
     return agents
@@ -329,7 +358,7 @@ def load_skills(
             frontmatter_match = re.match(r'^---\n(.*?)\n---\n(.*)$', content, re.DOTALL)
             if frontmatter_match:
                 yaml_content = frontmatter_match.group(1)
-                skill_meta = yaml.safe_load(yaml_content) or {}
+                skill_meta = _yaml_safe_load(yaml_content)
                 description = skill_meta.get('description', 'No description')
             else:
                 description = 'No description'

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -564,6 +564,16 @@ def cmd_doctor(args):
         print("❌ tmux: missing")
         print(f"   Fix: {_tmux_install_hint()}")
 
+    try:
+        import yaml  # type: ignore
+
+        _ = yaml
+        print("✅ pyyaml: found")
+    except Exception:
+        problems += 1
+        print("❌ pyyaml: missing")
+        print("   Fix: python3 -m pip install pyyaml")
+
     if agents_dir.exists() and agents_dir.is_dir():
         agents = list_all_agents(agents_dir)
         print(f"✅ agents/: found ({len(agents)} configured)")
@@ -1495,7 +1505,11 @@ Examples:
 
     handler = handlers.get(args.command)
     if handler:
-        return handler(args)
+        try:
+            return handler(args)
+        except RuntimeError as e:
+            print(f"❌ {e}")
+            return 1
 
     parser.print_help()
     return 1


### PR DESCRIPTION
Polish pass for agent-manager-skill to reduce installation footguns and make failures more actionable.

Changes:
- Clarify/declare the real Python dependency: `pyyaml` is required to parse YAML frontmatter (agents + injected skills).
- Improve error UX: missing PyYAML now fails with a clear one-line install hint instead of a raw ImportError.
- `doctor` now checks for `pyyaml` and reports a fix command.
- Add GitHub Actions CI (compile + unittest across Python 3.10/3.12).

This is intentionally small and low-risk: no runtime behavior change when deps are present.
