### PR TITLE
fix: clear codex input before sending task messages

### DIFF
--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -1011,8 +1011,17 @@ def cmd_send(args):
         print(f"   Start with: python3 {Path(__file__).name} start {agent_config.get('file_id', agent_name)}")
         return 1
 
+    launcher = resolve_launcher_command(agent_config.get('launcher', ''))
+    is_codex = 'codex' in launcher.lower()
+
     # Send message
-    if not send_keys(agent_id, args.message, send_enter=args.send_enter):
+    if not send_keys(
+        agent_id,
+        args.message,
+        send_enter=args.send_enter,
+        clear_input=is_codex,
+        escape_first=is_codex,
+    ):
         print(f"❌ Failed to send message to {agent_name}")
         return 1
 
@@ -1071,9 +1080,18 @@ def cmd_assign(args):
         print()
         time.sleep(3)  # Give Claude Code time to start
 
+    launcher = resolve_launcher_command(agent_config.get('launcher', ''))
+    is_codex = 'codex' in launcher.lower()
+
     # Send task
     task_message = f"# Task Assignment\n\n{task}"
-    if not send_keys(agent_id, task_message, send_enter=True):
+    if not send_keys(
+        agent_id,
+        task_message,
+        send_enter=True,
+        clear_input=is_codex,
+        escape_first=is_codex,
+    ):
         print(f"❌ Failed to assign task to {agent_name}")
         return 1
 
@@ -1219,8 +1237,17 @@ def cmd_heartbeat_run(args):
     # Standard heartbeat message
     heartbeat_message = "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."
 
+    launcher = resolve_launcher_command(agent_config.get('launcher', ''))
+    is_codex = 'codex' in launcher.lower()
+
     # Send heartbeat
-    if not send_keys(agent_id, heartbeat_message, send_enter=True):
+    if not send_keys(
+        agent_id,
+        heartbeat_message,
+        send_enter=True,
+        clear_input=is_codex,
+        escape_first=is_codex,
+    ):
         print(f"❌ Failed to send heartbeat to {agent_name}")
         return 1
 
@@ -1228,7 +1255,6 @@ def cmd_heartbeat_run(args):
 
     # Wait for response (if timeout specified)
     if timeout_seconds and timeout_seconds > 0:
-        launcher = resolve_launcher_command(agent_config.get('launcher', ''))
         start_time = time.time()
         poll_seconds = 2
 
@@ -1444,7 +1470,14 @@ def cmd_schedule_run(args):
                 f"Run scheduled job '{args.job}'. Read and follow instructions from file: {task_file}"
             )
 
-    if not send_keys(agent_id, task_message, send_enter=True):
+    is_codex = provider_key == 'codex'
+    if not send_keys(
+        agent_id,
+        task_message,
+        send_enter=True,
+        clear_input=is_codex,
+        escape_first=is_codex,
+    ):
         print(f"❌ Failed to send task to agent")
         return 1
 

--- a/agent-manager/scripts/tmux_helper.py
+++ b/agent-manager/scripts/tmux_helper.py
@@ -466,7 +466,14 @@ def capture_output(agent_id: str, lines: int = 100) -> Optional[str]:
     return result.stdout
 
 
-def send_keys(agent_id: str, keys: str, *, send_enter: bool = True) -> bool:
+def send_keys(
+    agent_id: str,
+    keys: str,
+    *,
+    send_enter: bool = True,
+    clear_input: bool = False,
+    escape_first: bool = False,
+) -> bool:
     """
     Send keys to a tmux session.
 
@@ -474,6 +481,8 @@ def send_keys(agent_id: str, keys: str, *, send_enter: bool = True) -> bool:
         agent_id: Agent ID (e.g., 'emp-0001', without agent- prefix)
         keys: Keys to send
         send_enter: Whether to send Enter after the keys (default: True)
+        clear_input: Whether to clear current input line before sending text
+        escape_first: Whether to send Escape before sending text
 
     Returns:
         True if keys were sent successfully
@@ -484,6 +493,14 @@ def send_keys(agent_id: str, keys: str, *, send_enter: bool = True) -> bool:
     target = _agent_pane_target(agent_id)
     if not target:
         return False
+
+    def _send_tmux_key(key: str) -> bool:
+        result = subprocess.run(
+            ['tmux', 'send-keys', '-t', target, key],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode == 0
 
     def _send_literal(text: str) -> bool:
         if not text:
@@ -515,6 +532,14 @@ def send_keys(agent_id: str, keys: str, *, send_enter: bool = True) -> bool:
             return True
         except Exception:
             return False
+
+    if escape_first:
+        _send_tmux_key('Escape')
+        time.sleep(0.05)
+
+    if clear_input:
+        _send_tmux_key('C-u')
+        time.sleep(0.05)
 
     # For multi-line content, paste via tmux buffer (more reliable than send-keys).
     if '\n' in keys:


### PR DESCRIPTION
## Summary
- detect Codex-launched agents in `main.py` and enable safe input sanitization for `send`, `assign`, `heartbeat run`, and `schedule run`
- extend `tmux_helper.send_keys` with optional `escape_first` + `clear_input` flags
- send `Escape` then `Ctrl-U` before task text for Codex sessions to prevent stale suggestion/input contamination

## Why
After Codex upgrades, tmux-injected messages can append to existing typed content in the prompt buffer. This causes malformed assignments and unreliable automation.

## Changes
- `agent-manager/scripts/main.py`
  - compute `is_codex` per agent/launcher
  - pass `clear_input=True` and `escape_first=True` in message-injection paths
- `agent-manager/scripts/tmux_helper.py`
  - add optional `clear_input` and `escape_first` params to `send_keys`
  - implement key sending helper and pre-send sanitization behavior

## Validation
- `python3 -m py_compile agent-manager/scripts/main.py agent-manager/scripts/tmux_helper.py`

