### PR TITLE
feat(agent-manager): support codex session restore

### DIFF
--- a/agent-manager/providers/__init__.py
+++ b/agent-manager/providers/__init__.py
@@ -28,7 +28,9 @@ PROVIDERS: Dict[str, Dict] = {
             'mode': 'unsupported',
         },
         'session_restore': {
-            'mode': 'unsupported',
+            # Codex supports `resume [SESSION_ID]` to continue an existing session.
+            'mode': 'cli_optional_arg',
+            'flag': 'resume',
         },
         'runtime': {
             'busy_patterns': [

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -252,6 +252,82 @@ def _find_new_claude_session_id_with_retry(cwd: str, *, before_jsonl_paths: set[
         time.sleep(0.2)
 
 
+def _codex_sessions_dir() -> Path:
+    return Path.home() / '.codex' / 'sessions'
+
+
+def _codex_session_exists(cwd: str, session_id: str) -> bool:
+    if not _looks_like_uuid(session_id):
+        return False
+    sessions_dir = _codex_sessions_dir()
+    if not sessions_dir.exists() or not sessions_dir.is_dir():
+        return False
+    try:
+        for p in sessions_dir.rglob('*.jsonl'):
+            if session_id in p.name:
+                return True
+        return False
+    except Exception:
+        return False
+
+
+def _snapshot_codex_sessions(cwd: str) -> set[str]:
+    sessions_dir = _codex_sessions_dir()
+    if not sessions_dir.exists() or not sessions_dir.is_dir():
+        return set()
+    return {str(p) for p in sessions_dir.rglob('*.jsonl')}
+
+
+def _extract_codex_session_id_from_jsonl(jsonl_path: Path) -> str:
+    try:
+        with jsonl_path.open('r', encoding='utf-8') as f:
+            for _ in range(10):
+                line = f.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                p = payload.get('payload') or {}
+                session_id = str(p.get('id') or '').strip()
+                if _looks_like_uuid(session_id):
+                    return session_id
+        return ""
+    except Exception:
+        return ""
+
+
+def _find_new_codex_session_id(cwd: str, *, before_jsonl_paths: set[str]) -> str:
+    sessions_dir = _codex_sessions_dir()
+    if not sessions_dir.exists() or not sessions_dir.is_dir():
+        return ""
+
+    candidates = [p for p in sessions_dir.rglob('*.jsonl') if str(p) not in before_jsonl_paths]
+    if not candidates:
+        candidates = list(sessions_dir.rglob('*.jsonl'))
+    if not candidates:
+        return ""
+
+    for candidate in sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True):
+        session_id = _extract_codex_session_id_from_jsonl(candidate)
+        if session_id:
+            return session_id
+
+    return ""
+
+
+def _find_new_codex_session_id_with_retry(cwd: str, *, before_jsonl_paths: set[str], timeout_s: float = 2.0) -> str:
+    deadline = time.time() + max(0.0, float(timeout_s))
+    while True:
+        session_id = _find_new_codex_session_id(cwd, before_jsonl_paths=before_jsonl_paths)
+        if session_id:
+            return session_id
+        if time.time() >= deadline:
+            return ""
+        time.sleep(0.2)
+
+
 def _opencode_storage_dir() -> Path:
     return Path.home() / '.local' / 'share' / 'opencode' / 'storage'
 
@@ -354,6 +430,8 @@ def _provider_session_exists(provider_key: str, cwd: str, session_id: str) -> bo
         return _droid_session_exists(cwd, session_id)
     if provider_key in {'claude', 'claude-code'}:
         return _claude_session_exists(cwd, session_id)
+    if provider_key == 'codex':
+        return _codex_session_exists(cwd, session_id)
     if provider_key == 'opencode':
         return _opencode_session_exists(cwd, session_id)
     return False
@@ -364,6 +442,8 @@ def _snapshot_provider_sessions(provider_key: str, cwd: str) -> set[str]:
         return _snapshot_droid_sessions(cwd)
     if provider_key in {'claude', 'claude-code'}:
         return _snapshot_claude_sessions(cwd)
+    if provider_key == 'codex':
+        return _snapshot_codex_sessions(cwd)
     if provider_key == 'opencode':
         return _snapshot_opencode_sessions(cwd)
     return set()
@@ -374,6 +454,8 @@ def _find_new_provider_session_id_with_retry(provider_key: str, cwd: str, *, bef
         return _find_new_droid_session_id_with_retry(cwd, before_jsonl_paths=before_paths, timeout_s=timeout_s)
     if provider_key in {'claude', 'claude-code'}:
         return _find_new_claude_session_id_with_retry(cwd, before_jsonl_paths=before_paths, timeout_s=timeout_s)
+    if provider_key == 'codex':
+        return _find_new_codex_session_id_with_retry(cwd, before_jsonl_paths=before_paths, timeout_s=timeout_s)
     if provider_key == 'opencode':
         return _find_new_opencode_session_id_with_retry(cwd, before_json_paths=before_paths, timeout_s=timeout_s)
     return ""
@@ -392,6 +474,8 @@ def _apply_session_restore_args(
     must stay first; claude options follow after.
     """
     launcher_lower = (launcher or "").lower()
+    if provider_key == 'codex' and restore_flag == 'resume':
+        return ['resume', session_id] + list(launcher_args or [])
     if provider_key == 'claude-code' and 'ccc' in launcher_lower:
         if launcher_args and not str(launcher_args[0]).startswith('-'):
             return [launcher_args[0], restore_flag, session_id] + launcher_args[1:]
@@ -711,7 +795,7 @@ def cmd_start(args):
     did_provider_restore = False
     provider_before_sessions: set[str] = set()
 
-    track_provider_session = provider_key in {'droid', 'claude', 'claude-code', 'opencode'}
+    track_provider_session = provider_key in {'droid', 'claude', 'claude-code', 'codex', 'opencode'}
     if provider_key == 'droid' and 'exec' in launcher_args:
         # `droid exec ...` doesn't create a resumable session in ~/.factory/sessions.
         track_provider_session = False

--- a/agent-manager/scripts/schedule_helper.py
+++ b/agent-manager/scripts/schedule_helper.py
@@ -234,6 +234,7 @@ def generate_crontab_entries(repo_root: Optional[Path] = None) -> str:
         cmd_parts = [
             f"cd {repo_root_q}",
             f"mkdir -p {log_dir_q}",
+            f"python3 {main_script_q} start {file_id_q} --restore",
             f"python3 {main_script_q} heartbeat run {file_id_q}",
         ]
 

--- a/agent-manager/scripts/tests/test_provider_restore.py
+++ b/agent-manager/scripts/tests/test_provider_restore.py
@@ -1,0 +1,37 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(SCRIPTS_DIR.parent) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR.parent))
+
+import main  # noqa: E402
+from providers import get_session_restore_flag, get_session_restore_mode  # noqa: E402
+
+
+class ProviderRestoreTests(unittest.TestCase):
+    def test_codex_provider_restore_config(self):
+        self.assertEqual(get_session_restore_mode("codex"), "cli_optional_arg")
+        self.assertEqual(get_session_restore_flag("codex"), "resume")
+
+    def test_codex_restore_args_are_prefixed_with_resume_and_session(self):
+        args = main._apply_session_restore_args(
+            provider_key="codex",
+            launcher="codex",
+            launcher_args=["--model=gpt-5.3-codex", "--dangerously-bypass-approvals-and-sandbox"],
+            restore_flag="resume",
+            session_id="019c3eb0-bca0-7ab0-8b93-3b54b5f582dc",
+        )
+        self.assertGreaterEqual(len(args), 2)
+        self.assertEqual(args[0], "resume")
+        self.assertEqual(args[1], "019c3eb0-bca0-7ab0-8b93-3b54b5f582dc")
+        self.assertIn("--model=gpt-5.3-codex", args)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Enable provider-level session restore for Codex via `resume`
- Add Codex session discovery/tracking from `~/.codex/sessions`
- Persist and reuse `session_id` in `start --restore`
- Build restore args as `codex resume <session_id> ...`
- Update heartbeat crontab generation to run `start --restore` before `heartbeat run`
- Add unit tests for restore config and arg composition

## Verification
- `python3 -m unittest discover -s agent-manager/scripts/tests -p 'test_*.py' -v`
- Result: 9 tests passed

## Why
This keeps Codex-based agents from losing continuity between runs, especially for scheduled heartbeat executions that should resume the same session context.