### PR TITLE
refactor(cli): extract list command handler module (slice-4 #46)

### DIFF
--- a/agent-manager/scripts/commands/__init__.py
+++ b/agent-manager/scripts/commands/__init__.py
@@ -1,8 +1,9 @@
 """Command handler modules for Agent Manager CLI."""
 
 from .lifecycle import cmd_assign, cmd_monitor, cmd_send, cmd_start, cmd_stop
-from .status import cmd_status
+from .listing import cmd_list
 from .schedule import cmd_schedule
+from .status import cmd_status
 
 __all__ = [
     'cmd_start',
@@ -10,6 +11,7 @@ __all__ = [
     'cmd_monitor',
     'cmd_send',
     'cmd_assign',
+    'cmd_list',
     'cmd_status',
     'cmd_schedule',
 ]

--- a/agent-manager/scripts/commands/listing.py
+++ b/agent-manager/scripts/commands/listing.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+
+def cmd_list(args, *, deps: Any):
+    """List all agents (configured and running)."""
+    list_all_agents = deps.list_all_agents
+    list_sessions = deps.list_sessions
+    get_agent_id = deps.get_agent_id
+    get_session_info = deps.get_session_info
+
+    all_agents = list_all_agents()
+    running_sessions = set(list_sessions())
+
+    print("📋 Agents:")
+    print()
+
+    if not all_agents:
+        print("  No agents configured in agents/")
+        return
+
+    for file_id, config in sorted(all_agents.items(), key=lambda item: item[0]):
+        agent_name = config.get('name') or file_id
+        agent_id = get_agent_id(config)
+        is_running = agent_id in running_sessions
+        is_enabled = config.get('enabled', True)
+
+        if args.running and not is_running:
+            continue
+
+        if is_running:
+            status = "✅ Running"
+            session_info = get_session_info(agent_id)
+            if session_info:
+                print(f"{status} {session_info['session']}({agent_name})")
+            else:
+                print(f"{status} agent-{agent_id}({agent_name})")
+        elif not is_enabled:
+            status = "⛔ Disabled"
+            print(f"{status} agent-{agent_id}({agent_name})")
+            print(f"   Description: {config.get('description', 'No description')}")
+            print(f"   Working Dir: {config.get('working_directory', 'N/A')}")
+            print()
+            continue
+        else:
+            status = "⭕ Stopped"
+            print(f"{status} agent-{agent_id}({agent_name})")
+
+        print(f"   Description: {config.get('description', 'No description')}")
+        print(f"   Working Dir: {config.get('working_directory', 'N/A')}")
+
+        skills = config.get('skills', [])
+        if skills:
+            print(f"   Skills: {', '.join(skills)}")
+
+        print()

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -88,6 +88,7 @@ from services.heartbeat_state_machine import (
     should_retry_heartbeat_attempt as service_should_retry_heartbeat_attempt,
 )
 from commands.status import cmd_status as status_cmd_status
+from commands.listing import cmd_list as listing_cmd_list
 from commands.schedule import cmd_schedule as schedule_cmd_schedule
 
 
@@ -1212,53 +1213,7 @@ def cmd_status(args):
 
 def cmd_list(args):
     """List all agents (configured and running)."""
-    all_agents = list_all_agents()
-    running_sessions = set(list_sessions())
-
-    print("📋 Agents:")
-    print()
-
-    if not all_agents:
-        print("  No agents configured in agents/")
-        return
-
-    for file_id, config in sorted(all_agents.items(), key=lambda item: item[0]):
-        agent_name = config.get('name') or file_id
-        agent_id = get_agent_id(config)
-        is_running = agent_id in running_sessions
-        is_enabled = config.get('enabled', True)
-
-        # Skip if --running and not active
-        if args.running and not is_running:
-            continue
-
-        # Status indicator - show: agent-emp-0001(dev)
-        if is_running:
-            status = "✅ Running"
-            session_info = get_session_info(agent_id)
-            if session_info:
-                print(f"{status} {session_info['session']}({agent_name})")
-            else:
-                print(f"{status} agent-{agent_id}({agent_name})")
-        elif not is_enabled:
-            status = "⛔ Disabled"
-            print(f"{status} agent-{agent_id}({agent_name})")
-            print(f"   Description: {config.get('description', 'No description')}")
-            print(f"   Working Dir: {config.get('working_directory', 'N/A')}")
-            print()
-            continue
-        else:
-            status = "⭕ Stopped"
-            print(f"{status} agent-{agent_id}({agent_name})")
-
-        print(f"   Description: {config.get('description', 'No description')}")
-        print(f"   Working Dir: {config.get('working_directory', 'N/A')}")
-
-        skills = config.get('skills', [])
-        if skills:
-            print(f"   Skills: {', '.join(skills)}")
-
-        print()
+    return listing_cmd_list(args, deps=_lifecycle_deps_module())
 
 
 def _tmux_install_hint() -> str:

--- a/agent-manager/scripts/tests/test_cli_modular_slice1.py
+++ b/agent-manager/scripts/tests/test_cli_modular_slice1.py
@@ -105,6 +105,15 @@ class CliModularSlice1Tests(unittest.TestCase):
         mock_handler.assert_called_once()
         self.assertIs(mock_handler.call_args.kwargs['deps'], main)
 
+    def test_list_wrapper_delegates_to_listing_handler(self):
+        args = object()
+        with patch('main.listing_cmd_list', return_value=37) as mock_handler:
+            result = main.cmd_list(args)
+
+        self.assertEqual(result, 37)
+        mock_handler.assert_called_once()
+        self.assertIs(mock_handler.call_args.kwargs['deps'], main)
+
     def test_schedule_wrapper_delegates_to_schedule_handler(self):
         args = object()
         with patch('main.schedule_cmd_schedule', return_value=31) as mock_handler:

--- a/agent-manager/scripts/tests/test_list_command.py
+++ b/agent-manager/scripts/tests/test_list_command.py
@@ -1,0 +1,85 @@
+import argparse
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from commands.listing import cmd_list  # noqa: E402
+
+
+class _Deps:
+    @staticmethod
+    def list_all_agents():
+        return {
+            'EMP_0001': {
+                'file_id': 'EMP_0001',
+                'name': 'dev',
+                'description': 'Dev agent',
+                'working_directory': '/tmp/dev',
+                'skills': ['review-pr'],
+                'enabled': True,
+            },
+            'EMP_0002': {
+                'file_id': 'EMP_0002',
+                'name': 'qa',
+                'description': 'QA agent',
+                'working_directory': '/tmp/qa',
+                'enabled': False,
+            },
+            'EMP_0003': {
+                'file_id': 'EMP_0003',
+                'name': 'ops',
+                'description': 'Ops agent',
+                'working_directory': '/tmp/ops',
+                'enabled': True,
+            },
+        }
+
+    @staticmethod
+    def list_sessions():
+        return ['emp-0001']
+
+    @staticmethod
+    def get_agent_id(config):
+        return config.get('file_id', '').lower().replace('_', '-')
+
+    @staticmethod
+    def get_session_info(agent_id):
+        if agent_id == 'emp-0001':
+            return {'session': 'agent-emp-0001'}
+        return None
+
+
+class ListCommandTests(unittest.TestCase):
+    def _run(self, running=False):
+        out = io.StringIO()
+        args = argparse.Namespace(running=running)
+        with redirect_stdout(out):
+            cmd_list(args, deps=_Deps)
+        return out.getvalue()
+
+    def test_list_shows_running_stopped_and_disabled(self):
+        text = self._run(running=False)
+
+        self.assertIn('📋 Agents:', text)
+        self.assertIn('✅ Running agent-emp-0001(dev)', text)
+        self.assertIn('⭕ Stopped agent-emp-0003(ops)', text)
+        self.assertIn('⛔ Disabled agent-emp-0002(qa)', text)
+        self.assertIn('Skills: review-pr', text)
+
+    def test_list_running_filter_only_shows_running(self):
+        text = self._run(running=True)
+
+        self.assertIn('✅ Running agent-emp-0001(dev)', text)
+        self.assertNotIn('⭕ Stopped agent-emp-0003(ops)', text)
+        self.assertNotIn('⛔ Disabled agent-emp-0002(qa)', text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary\n- extract `list` command logic from `agent-manager/scripts/main.py` into new module `agent-manager/scripts/commands/listing.py`\n- keep `main.cmd_list` as a thin wrapper delegating through dependency injection (same pattern as status/schedule/lifecycle modules)\n- add regression tests for list command output/filter behavior and wrapper delegation\n\nCloses #46 (slice-4 progress).\n\n## Validation\n- `python3 -m compileall -q agent-manager`\n- `python3 -m unittest -q agent-manager/scripts/tests/test_cli_modular_slice1.py agent-manager/scripts/tests/test_list_command.py`\n- `python3 -m unittest discover -s agent-manager/scripts/tests -p 'test_*.py' -q`\n\n## Risk\n- low risk: functional behavior should stay equivalent; only command extraction/refactor\n- possible risk: output formatting drift in `list` command\n\n## Rollback\n- revert this PR commit to restore inline `cmd_list` implementation in `main.py`\n- no data migration/state change involved