### PR TITLE
docs(readme): prefer npx openskills workflow (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ Managing multiple AI agents is deceptively complex:
 ### via openskills (recommended)
 
 ```bash
-# Project installation
-openskills install fractalmind-ai/agent-manager-skill
+# Project installation (works even when `openskills` is not globally installed)
+npx --yes openskills install fractalmind-ai/agent-manager-skill
 
 # Global installation
-openskills install fractalmind-ai/agent-manager-skill --global
+npx --yes openskills install fractalmind-ai/agent-manager-skill --global
+
+# If you already have a global openskills binary, this also works:
+# openskills install fractalmind-ai/agent-manager-skill
 ```
 
 ### Manual installation
@@ -54,7 +57,11 @@ cp -r agent-manager ~/.claude/skills/agent-manager
 After installation, read the skill documentation:
 
 ```bash
-openskills read agent-manager
+# Preferred (portable)
+npx --yes openskills read agent-manager
+
+# Optional when openskills is globally installed:
+# openskills read agent-manager
 ```
 
 Or view directly:


### PR DESCRIPTION
## Summary
- update README install/read examples to prefer `npx --yes openskills ...` so commands are executable even when `openskills` is not globally installed
- keep global `openskills` fallback note for backward compatibility

Closes #57 (slice-1 minimal increment).

## Validation
- local executable sanity check used for decision: `npx --yes openskills --help`

## Risk
- low; docs-only change
- potential confusion for users who strongly prefer global binary flow

## Rollback
- revert this PR commit to restore previous README command examples
