### PR TITLE
refactor(cli): extract doctor command handler module (slice-5 #46)

### DIFF
--- a/agent-manager/scripts/commands/__init__.py
+++ b/agent-manager/scripts/commands/__init__.py
@@ -1,6 +1,7 @@
 """Command handler modules for Agent Manager CLI."""
 
 from .lifecycle import cmd_assign, cmd_monitor, cmd_send, cmd_start, cmd_stop
+from .doctor import cmd_doctor
 from .listing import cmd_list
 from .schedule import cmd_schedule
 from .status import cmd_status
@@ -11,6 +12,7 @@ __all__ = [
     'cmd_monitor',
     'cmd_send',
     'cmd_assign',
+    'cmd_doctor',
     'cmd_list',
     'cmd_status',
     'cmd_schedule',

--- a/agent-manager/scripts/commands/doctor.py
+++ b/agent-manager/scripts/commands/doctor.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+
+def cmd_doctor(args, *, deps: Any):
+    """Run basic environment checks for agent-manager."""
+    get_repo_root = deps.get_repo_root
+    check_tmux = deps.check_tmux
+    list_all_agents = deps.list_all_agents
+    get_agent_id = deps.get_agent_id
+    resolve_launcher_command = deps.resolve_launcher_command
+    Path = deps.Path
+    sys = deps.sys
+    subprocess = deps.subprocess
+
+    repo_root = get_repo_root()
+    agents_dir = repo_root / 'agents'
+    skills_dir = repo_root / '.agent' / 'skills'
+    claude_dir = repo_root / '.claude'
+
+    problems = 0
+
+    print("🩺 agent-manager doctor")
+    print()
+    print(f"Repo root: {repo_root}")
+    print(f"Python: {sys.version.split()[0]} ({sys.executable})")
+    print(f"Platform: {sys.platform}")
+    print()
+
+    if check_tmux():
+        print("✅ tmux: found")
+    else:
+        problems += 1
+        print("❌ tmux: missing")
+        print(f"   Fix: {deps._tmux_install_hint()}")
+
+    if agents_dir.exists() and agents_dir.is_dir():
+        agents = list_all_agents(agents_dir)
+        print(f"✅ agents/: found ({len(agents)} configured)")
+    else:
+        problems += 1
+        print("❌ agents/: missing")
+        print(f"   Expected at: {agents_dir}")
+
+    if skills_dir.exists() and skills_dir.is_dir():
+        print("✅ .agent/skills/: found")
+    else:
+        print("⚠️  .agent/skills/: missing")
+        print(f"   Expected at: {skills_dir}")
+
+    if claude_dir.exists() and claude_dir.is_dir():
+        print("✅ .claude/: found")
+    else:
+        print("⚠️  .claude/: missing")
+        print(f"   Expected at: {claude_dir}")
+
+    try:
+        result = subprocess.run(['crontab', '-l'], capture_output=True, text=True)
+        if result.returncode == 0:
+            print("✅ crontab: readable")
+        else:
+            print("⚠️  crontab: not set (or not readable)")
+    except FileNotFoundError:
+        problems += 1
+        print("❌ crontab: command not found")
+
+    if args.deep and agents_dir.exists() and agents_dir.is_dir():
+        print()
+        print("🔎 Deep checks:")
+        agents = list_all_agents(agents_dir)
+        for file_id, config in sorted(agents.items(), key=lambda item: item[0]):
+            agent_id = get_agent_id(config)
+            working_dir = config.get('working_directory')
+            launcher = resolve_launcher_command(config.get('launcher', ''))
+            enabled = config.get('enabled', True)
+
+            status = "✅" if enabled else "⛔"
+            print(f"{status} {file_id} (agent-{agent_id})")
+            if working_dir:
+                wd_ok = Path(working_dir).exists()
+                print(f"   Working dir: {working_dir} ({'ok' if wd_ok else 'missing'})")
+                if not wd_ok and enabled:
+                    problems += 1
+            else:
+                print("   Working dir: (not set)")
+                if enabled:
+                    problems += 1
+
+            if launcher:
+                print(f"   Launcher: {launcher}")
+            else:
+                print("   Launcher: (not set)")
+
+    print()
+    if problems:
+        print(f"❌ Doctor found {problems} problem(s)")
+        return 1
+    print("✅ Doctor checks passed")
+    return 0

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -89,6 +89,7 @@ from services.heartbeat_state_machine import (
 )
 from commands.status import cmd_status as status_cmd_status
 from commands.listing import cmd_list as listing_cmd_list
+from commands.doctor import cmd_doctor as doctor_cmd_doctor
 from commands.schedule import cmd_schedule as schedule_cmd_schedule
 
 
@@ -1226,91 +1227,7 @@ def _tmux_install_hint() -> str:
 
 def cmd_doctor(args):
     """Run basic environment checks for agent-manager."""
-    repo_root = get_repo_root()
-    agents_dir = repo_root / 'agents'
-    skills_dir = repo_root / '.agent' / 'skills'
-    claude_dir = repo_root / '.claude'
-
-    problems = 0
-
-    print("🩺 agent-manager doctor")
-    print()
-    print(f"Repo root: {repo_root}")
-    print(f"Python: {sys.version.split()[0]} ({sys.executable})")
-    print(f"Platform: {sys.platform}")
-    print()
-
-    if check_tmux():
-        print("✅ tmux: found")
-    else:
-        problems += 1
-        print("❌ tmux: missing")
-        print(f"   Fix: {_tmux_install_hint()}")
-
-    if agents_dir.exists() and agents_dir.is_dir():
-        agents = list_all_agents(agents_dir)
-        print(f"✅ agents/: found ({len(agents)} configured)")
-    else:
-        problems += 1
-        print("❌ agents/: missing")
-        print(f"   Expected at: {agents_dir}")
-
-    if skills_dir.exists() and skills_dir.is_dir():
-        print("✅ .agent/skills/: found")
-    else:
-        print("⚠️  .agent/skills/: missing")
-        print(f"   Expected at: {skills_dir}")
-
-    if claude_dir.exists() and claude_dir.is_dir():
-        print("✅ .claude/: found")
-    else:
-        print("⚠️  .claude/: missing")
-        print(f"   Expected at: {claude_dir}")
-
-    try:
-        result = subprocess.run(['crontab', '-l'], capture_output=True, text=True)
-        if result.returncode == 0:
-            print("✅ crontab: readable")
-        else:
-            # macOS exits non-zero when no crontab exists; treat as warning.
-            print("⚠️  crontab: not set (or not readable)")
-    except FileNotFoundError:
-        problems += 1
-        print("❌ crontab: command not found")
-
-    if args.deep and agents_dir.exists() and agents_dir.is_dir():
-        print()
-        print("🔎 Deep checks:")
-        agents = list_all_agents(agents_dir)
-        for file_id, config in sorted(agents.items(), key=lambda item: item[0]):
-            agent_id = get_agent_id(config)
-            working_dir = config.get('working_directory')
-            launcher = resolve_launcher_command(config.get('launcher', ''))
-            enabled = config.get('enabled', True)
-
-            status = "✅" if enabled else "⛔"
-            print(f"{status} {file_id} (agent-{agent_id})")
-            if working_dir:
-                wd_ok = Path(working_dir).exists()
-                print(f"   Working dir: {working_dir} ({'ok' if wd_ok else 'missing'})")
-                if not wd_ok and enabled:
-                    problems += 1
-            else:
-                print("   Working dir: (not set)")
-                if enabled:
-                    problems += 1
-
-            if launcher:
-                print(f"   Launcher: {launcher}")
-            else:
-                print("   Launcher: (not set)")
-
-    print()
-    if problems:
-        print(f"❌ Doctor found {problems} problem(s)")
-        return 1
-    print("✅ Doctor checks passed")
-    return 0
+    return doctor_cmd_doctor(args, deps=_lifecycle_deps_module())
 
 
 def _lifecycle_deps_module():

--- a/agent-manager/scripts/tests/test_cli_modular_slice1.py
+++ b/agent-manager/scripts/tests/test_cli_modular_slice1.py
@@ -114,6 +114,15 @@ class CliModularSlice1Tests(unittest.TestCase):
         mock_handler.assert_called_once()
         self.assertIs(mock_handler.call_args.kwargs['deps'], main)
 
+    def test_doctor_wrapper_delegates_to_doctor_handler(self):
+        args = object()
+        with patch('main.doctor_cmd_doctor', return_value=41) as mock_handler:
+            result = main.cmd_doctor(args)
+
+        self.assertEqual(result, 41)
+        mock_handler.assert_called_once()
+        self.assertIs(mock_handler.call_args.kwargs['deps'], main)
+
     def test_schedule_wrapper_delegates_to_schedule_handler(self):
         args = object()
         with patch('main.schedule_cmd_schedule', return_value=31) as mock_handler:

--- a/agent-manager/scripts/tests/test_doctor_command.py
+++ b/agent-manager/scripts/tests/test_doctor_command.py
@@ -1,0 +1,123 @@
+import argparse
+import io
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from commands.doctor import cmd_doctor  # noqa: E402
+
+
+class _SubprocessOk:
+    @staticmethod
+    def run(*args, **kwargs):
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+
+class _SubprocessMissing:
+    @staticmethod
+    def run(*args, **kwargs):
+        raise FileNotFoundError
+
+
+class DoctorCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_root = Path(tempfile.mkdtemp(prefix='agent-manager-doctor-'))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_root, ignore_errors=True)
+
+    def test_doctor_happy_path(self):
+        (self.temp_root / 'agents').mkdir(parents=True, exist_ok=True)
+        (self.temp_root / '.agent' / 'skills').mkdir(parents=True, exist_ok=True)
+        (self.temp_root / '.claude').mkdir(parents=True, exist_ok=True)
+
+        class Deps:
+            sys = sys
+            subprocess = _SubprocessOk
+            Path = Path
+
+            @staticmethod
+            def get_repo_root():
+                return self.temp_root
+
+            @staticmethod
+            def check_tmux():
+                return True
+
+            @staticmethod
+            def list_all_agents(_agents_dir=None):
+                return {'EMP_0001': {'file_id': 'EMP_0001', 'enabled': True}}
+
+            @staticmethod
+            def get_agent_id(config):
+                return config.get('file_id', '').lower().replace('_', '-')
+
+            @staticmethod
+            def resolve_launcher_command(_launcher):
+                return 'codex'
+
+            @staticmethod
+            def _tmux_install_hint():
+                return 'install tmux'
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = cmd_doctor(argparse.Namespace(deep=False), deps=Deps)
+
+        text = out.getvalue()
+        self.assertEqual(code, 0)
+        self.assertIn('✅ Doctor checks passed', text)
+
+    def test_doctor_reports_missing_tmux_and_crontab(self):
+        class Deps:
+            sys = sys
+            subprocess = _SubprocessMissing
+            Path = Path
+
+            @staticmethod
+            def get_repo_root():
+                return self.temp_root
+
+            @staticmethod
+            def check_tmux():
+                return False
+
+            @staticmethod
+            def list_all_agents(_agents_dir=None):
+                return {}
+
+            @staticmethod
+            def get_agent_id(config):
+                return config.get('file_id', '').lower().replace('_', '-')
+
+            @staticmethod
+            def resolve_launcher_command(_launcher):
+                return ''
+
+            @staticmethod
+            def _tmux_install_hint():
+                return 'install tmux'
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = cmd_doctor(argparse.Namespace(deep=False), deps=Deps)
+
+        text = out.getvalue()
+        self.assertEqual(code, 1)
+        self.assertIn('❌ tmux: missing', text)
+        self.assertIn('❌ crontab: command not found', text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract `cmd_doctor` implementation from `agent-manager/scripts/main.py` into `agent-manager/scripts/commands/doctor.py`
- keep `main.cmd_doctor` as thin wrapper delegating via dependency injection
- add modularization regression coverage:
  - wrapper delegation assertion in `test_cli_modular_slice1.py`
  - new command behavior tests in `test_doctor_command.py`

Relates to #46.

## Validation
- `python3 -m compileall -q agent-manager`
- `python3 -m unittest -q agent-manager/scripts/tests/test_cli_modular_slice1.py agent-manager/scripts/tests/test_doctor_command.py`
- `python3 -m unittest discover -s agent-manager/scripts/tests -p 'test_*.py' -q`

## Risk
- low-to-medium: refactor-only but `doctor` output path is broad and dependency-heavy
- potential risk is missing dependency wiring during delegation

## Rollback
- revert commit `01bc13d` to restore inline `cmd_doctor` implementation in `main.py`
- no schema/data migration involved
