### PR TITLE
docs(parity): add canonical CLI alias baseline across docs (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ tmux attach -t agent-manager
 REPO_ROOT="$PWD/your-project" python3 agent-manager/scripts/main.py doctor
 ```
 
+### Command Path Parity (Docs Baseline)
+
+To avoid path drift across docs and runbooks, define one CLI alias and reuse it:
+
+```bash
+# Installed skill path (pick one that exists in your environment)
+CLI="python3 .agent/skills/agent-manager/scripts/main.py"
+# CLI="python3 .claude/skills/agent-manager/scripts/main.py"
+
+# If running from a cloned repo (not installed):
+# CLI="python3 agent-manager/scripts/main.py"
+
+$CLI doctor
+$CLI list
+$CLI status EMP_0001
+```
+
 ## Getting Started
 
 See `examples/getting-started.md` for a 2-minute end-to-end walkthrough.

--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -33,6 +33,23 @@ EOF
 python3 .agent/skills/agent-manager/scripts/main.py stop dev
 ```
 
+### Command Path Parity (Docs Baseline)
+
+For consistency with `README.md` and runbook examples, define one CLI alias and reuse it in your session:
+
+```bash
+# Installed skill path (pick one that exists)
+CLI="python3 .agent/skills/agent-manager/scripts/main.py"
+# CLI="python3 .claude/skills/agent-manager/scripts/main.py"
+
+# If operating from a cloned repo instead of installed skill:
+# CLI="python3 agent-manager/scripts/main.py"
+
+$CLI doctor
+$CLI list
+$CLI status EMP_0001
+```
+
 ## Core Concepts
 
 ### Agent Configuration


### PR DESCRIPTION
## Summary
- add a shared "Command Path Parity (Docs Baseline)" section in:
  - `README.md`
  - `agent-manager/SKILL.md`
- standardize a reusable `CLI="python3 .../main.py"` alias pattern to reduce path drift across docs and runbook operations
- include both installed-skill and cloned-repo path options in one place

Relates to #51.

## Validation
- `python3 -m compileall -q agent-manager`
- `python3 -m unittest discover -s agent-manager/scripts/tests -p 'test_*.py' -q`

## Risk
- low risk (docs-only)
- potential risk: users may still copy the wrong path variant for their environment

## Rollback
- revert commit `46d0f24` to restore previous wording in `README.md` and `agent-manager/SKILL.md`
