### PR TITLE
docs(runbook): align CLI path baseline with README/SKILL parity (#51)

### DIFF
--- a/agent-manager/docs/runbook-checklist.md
+++ b/agent-manager/docs/runbook-checklist.md
@@ -4,10 +4,15 @@ This runbook is an actionable SOP for day-to-day operation and common failures.
 
 ## 0) 30-Minute Newcomer Path
 
-Use this exact sequence from repo root:
+Use this exact sequence from repo root (choose one CLI path first):
 
 ```bash
-CLI="python3 agent-manager/scripts/main.py"
+# Installed skill path (pick one that exists in your environment)
+CLI="python3 .agent/skills/agent-manager/scripts/main.py"
+# CLI="python3 .claude/skills/agent-manager/scripts/main.py"
+
+# If running directly from a cloned repo (not installed skill):
+# CLI="python3 agent-manager/scripts/main.py"
 
 $CLI doctor
 $CLI list
@@ -26,7 +31,7 @@ Checklist:
 ## 1) Preflight Before Heartbeat / Schedule Operations
 
 ```bash
-CLI="python3 agent-manager/scripts/main.py"
+# Reuse CLI defined in section 0
 $CLI doctor
 $CLI heartbeat list
 $CLI schedule list
@@ -46,7 +51,7 @@ Symptoms:
 Commands:
 
 ```bash
-CLI="python3 agent-manager/scripts/main.py"
+# Reuse CLI defined in section 0
 $CLI heartbeat run EMP_0001 --timeout 30
 $CLI heartbeat trace --agent EMP_0001 --limit 20
 $CLI status EMP_0001
@@ -68,7 +73,7 @@ Symptoms:
 Commands:
 
 ```bash
-CLI="python3 agent-manager/scripts/main.py"
+# Reuse CLI defined in section 0
 $CLI status EMP_0001
 $CLI monitor EMP_0001 -n 160
 $CLI heartbeat run EMP_0001 --timeout 20


### PR DESCRIPTION
## Summary
- update `agent-manager/docs/runbook-checklist.md` to align CLI path usage with the docs baseline used in `README.md` and `agent-manager/SKILL.md`
- add one canonical CLI alias block in section 0 with installed-skill and cloned-repo options
- update sections 1/2/3 to explicitly reuse the same `CLI` alias to reduce path drift

Relates to #51.

## Validation
- `python3 -m compileall -q agent-manager`
- `python3 -m unittest discover -s agent-manager/scripts/tests -p 'test_*.py' -q`

## Risk
- low (docs-only)
- residual risk: users may still pick the wrong CLI variant for their environment

## Rollback
- revert commit `f99be48` to restore previous runbook command blocks
