### PR TITLE
fix: avoid heartbeat preflight false-idle via multi-sample pane activity detection

### DIFF
--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -684,6 +684,60 @@ def _wait_for_idle_after_handoff(agent_id: str, launcher: str, timeout_seconds: 
     return last_state
 
 
+_HEARTBEAT_PREFLIGHT_SAMPLE_COUNT = 3
+_HEARTBEAT_PREFLIGHT_SAMPLE_INTERVAL_SECONDS = 2.0
+_HEARTBEAT_PREFLIGHT_CAPTURE_LINES = 120
+
+
+def _heartbeat_preflight_runtime_state(
+    *,
+    agent_id: str,
+    launcher: str,
+    sample_count: int = _HEARTBEAT_PREFLIGHT_SAMPLE_COUNT,
+    sample_interval_seconds: float = _HEARTBEAT_PREFLIGHT_SAMPLE_INTERVAL_SECONDS,
+    capture_lines: int = _HEARTBEAT_PREFLIGHT_CAPTURE_LINES,
+) -> tuple[str, str]:
+    """Best-effort heartbeat preflight state.
+
+    For auto-mode heartbeat gating we avoid relying on one snapshot only.
+    If pane output changes across idle samples, treat the agent as active (busy)
+    to prevent heartbeat injection from interrupting an in-progress conversation.
+    """
+    runtime = get_agent_runtime_state(agent_id, launcher=launcher)
+    state = str(runtime.get('state', 'unknown'))
+    reason = str(runtime.get('reason', 'unknown'))
+    if state != 'idle':
+        return state, reason
+
+    samples = max(1, int(sample_count))
+    interval = max(0.1, float(sample_interval_seconds))
+    lines = max(20, int(capture_lines))
+
+    previous_output = capture_output(agent_id, lines=lines)
+    if previous_output is None:
+        previous_output = ""
+
+    for sample_index in range(1, samples):
+        time.sleep(interval)
+
+        runtime = get_agent_runtime_state(agent_id, launcher=launcher)
+        state = str(runtime.get('state', 'unknown'))
+        reason = str(runtime.get('reason', 'unknown'))
+        if state != 'idle':
+            return state, reason
+
+        current_output = capture_output(agent_id, lines=lines)
+        if current_output is None:
+            current_output = ""
+
+        if current_output != previous_output:
+            return 'busy', f'preflight_pane_changed:{sample_index}'
+
+        previous_output = current_output
+
+    return 'idle', reason
+
+
 
 
 def _heartbeat_audit_dir(repo_root: Path) -> Path:
@@ -1358,10 +1412,16 @@ def cmd_heartbeat_run(args):
     heartbeat_id = time.strftime('%Y%m%d-%H%M%S')
     print(f"   HB_ID: {heartbeat_id}")
 
-    preflight_runtime = get_agent_runtime_state(agent_id, launcher=launcher)
-    preflight_state = str(preflight_runtime.get('state', 'unknown'))
-    preflight_reason = str(preflight_runtime.get('reason', 'unknown'))
+    preflight_state, preflight_reason = _heartbeat_preflight_runtime_state(
+        agent_id=agent_id,
+        launcher=launcher,
+    )
     if session_mode == 'auto' and preflight_state in {'busy', 'stuck', 'blocked', 'error'}:
+        skip_failure_type = 'busy_skip'
+        skip_reason_code = 'HB_AUTO_BUSY_SKIP'
+        if preflight_state == 'busy' and str(preflight_reason).startswith('preflight_pane_changed:'):
+            skip_failure_type = 'active_skip'
+            skip_reason_code = 'HB_AUTO_ACTIVE_SKIP'
         print(
             "⏭️  Agent is not idle "
             f"(state={preflight_state}, reason={preflight_reason}); "
@@ -1375,12 +1435,12 @@ def cmd_heartbeat_run(args):
             ack_status='not_checked',
             duration_ms=0,
             context_left=context_left_percent,
-            failure_type='busy_skip',
+            failure_type=skip_failure_type,
             session_mode=session_mode,
             phase='preflight',
             attempt=0,
             recovery_action='skip_busy',
-            reason_code='HB_AUTO_BUSY_SKIP',
+            reason_code=skip_reason_code,
         )
         return 0
 

--- a/agent-manager/scripts/tests/test_heartbeat_recovery.py
+++ b/agent-manager/scripts/tests/test_heartbeat_recovery.py
@@ -63,6 +63,44 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         self.assertFalse(main._should_retry_heartbeat_attempt(failure_type='unknown', attempt_index=0, max_retries=1))
         self.assertFalse(main._should_retry_heartbeat_attempt(failure_type='send_fail', attempt_index=1, max_retries=1))
 
+    @patch('main.time.sleep', return_value=None)
+    @patch('main.capture_output', side_effect=['pane-a', 'pane-b'])
+    @patch('main.get_agent_runtime_state', return_value={'state': 'idle', 'reason': 'ready'})
+    def test_heartbeat_preflight_detects_active_when_pane_changes(
+        self,
+        _mock_runtime,
+        _mock_capture,
+        _mock_sleep,
+    ):
+        state, reason = main._heartbeat_preflight_runtime_state(
+            agent_id='emp-0001',
+            launcher='codex',
+            sample_count=2,
+            sample_interval_seconds=0.1,
+            capture_lines=40,
+        )
+        self.assertEqual(state, 'busy')
+        self.assertTrue(reason.startswith('preflight_pane_changed:'))
+
+    @patch('main.time.sleep', return_value=None)
+    @patch('main.capture_output', side_effect=['pane-a', 'pane-a'])
+    @patch('main.get_agent_runtime_state', return_value={'state': 'idle', 'reason': 'ready'})
+    def test_heartbeat_preflight_keeps_idle_when_pane_stable(
+        self,
+        _mock_runtime,
+        _mock_capture,
+        _mock_sleep,
+    ):
+        state, reason = main._heartbeat_preflight_runtime_state(
+            agent_id='emp-0001',
+            launcher='codex',
+            sample_count=2,
+            sample_interval_seconds=0.1,
+            capture_lines=40,
+        )
+        self.assertEqual(state, 'idle')
+        self.assertEqual(reason, 'ready')
+
     @patch('main.send_keys', return_value=False)
     def test_run_heartbeat_attempt_send_fail(self, _mock_send):
         result = main._run_heartbeat_attempt(
@@ -313,8 +351,8 @@ class HeartbeatRecoveryTests(unittest.TestCase):
     @patch('main.time.sleep', return_value=None)
     @patch('main._run_heartbeat_attempt')
     @patch('main._maybe_rollover_heartbeat_session', return_value=None)
+    @patch('main._heartbeat_preflight_runtime_state', return_value=('busy', 'busy_pattern:Thinking...'))
     @patch('main._detect_agent_context_left_percent', return_value=55)
-    @patch('main.get_agent_runtime_state', return_value={'state': 'busy', 'reason': 'busy_pattern:Thinking...'})
     @patch('main.resolve_launcher_command', return_value='codex')
     @patch('main.session_exists', return_value=True)
     @patch('main.resolve_agent')
@@ -325,8 +363,8 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         mock_resolve_agent,
         _mock_session,
         _mock_launcher,
-        _mock_runtime,
         _mock_context,
+        _mock_preflight,
         _mock_rollover,
         mock_run_attempt,
         _mock_sleep,
@@ -364,6 +402,64 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         mock_audit.assert_called_once()
         self.assertEqual(mock_audit.call_args.kwargs.get('phase'), 'preflight')
         self.assertEqual(mock_audit.call_args.kwargs.get('failure_type'), 'busy_skip')
+        self.assertEqual(mock_audit.call_args.kwargs.get('reason_code'), 'HB_AUTO_BUSY_SKIP')
+
+    @patch('main._append_heartbeat_audit_event')
+    @patch('main.time.sleep', return_value=None)
+    @patch('main._run_heartbeat_attempt')
+    @patch('main._maybe_rollover_heartbeat_session', return_value=None)
+    @patch('main._heartbeat_preflight_runtime_state', return_value=('busy', 'preflight_pane_changed:1'))
+    @patch('main._detect_agent_context_left_percent', return_value=55)
+    @patch('main.resolve_launcher_command', return_value='codex')
+    @patch('main.session_exists', return_value=True)
+    @patch('main.resolve_agent')
+    @patch('main.check_tmux', return_value=True)
+    def test_cmd_heartbeat_run_auto_mode_skips_when_preflight_detects_active_pane(
+        self,
+        _mock_tmux,
+        mock_resolve_agent,
+        _mock_session,
+        _mock_launcher,
+        _mock_context,
+        _mock_preflight,
+        _mock_rollover,
+        mock_run_attempt,
+        _mock_sleep,
+        mock_audit,
+    ):
+        mock_resolve_agent.return_value = {
+            'name': 'qa-agent',
+            'file_id': 'EMP_0001',
+            'enabled': True,
+            'heartbeat': {
+                'enabled': True,
+                'session_mode': 'auto',
+                'recovery': {
+                    'max_retries': 1,
+                    'retry_backoff_seconds': 0,
+                    'fallback_mode': 'none',
+                },
+            },
+            'launcher': 'codex',
+        }
+
+        args = type('Args', (), {
+            'agent': 'EMP_0001',
+            'timeout': None,
+            'retry': None,
+            'backoff_seconds': 0,
+            'fallback_mode': None,
+            'notify_on_failure': False,
+            'notifier_channel': None,
+        })()
+
+        result = main.cmd_heartbeat_run(args)
+        self.assertEqual(result, 0)
+        mock_run_attempt.assert_not_called()
+        mock_audit.assert_called_once()
+        self.assertEqual(mock_audit.call_args.kwargs.get('phase'), 'preflight')
+        self.assertEqual(mock_audit.call_args.kwargs.get('failure_type'), 'active_skip')
+        self.assertEqual(mock_audit.call_args.kwargs.get('reason_code'), 'HB_AUTO_ACTIVE_SKIP')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix heartbeat auto-mode preflight false-idle gap by adding multi-sample runtime detection
- when initial runtime is idle, sample pane output across multiple captures; if pane changes while state remains idle, treat as active and skip heartbeat injection
- keep existing busy/stuck/blocked/error preflight skip behavior and add explicit audit reason code for pane-activity skip

## Implementation
- add `_heartbeat_preflight_runtime_state(...)` in `agent-manager/scripts/main.py`
  - default sampling: 3 captures, 2s interval, 120 lines
  - returns `busy` with reason `preflight_pane_changed:<n>` when pane output changes during idle window
- use helper in `cmd_heartbeat_run` preflight path
- map pane-activity skip to audit:
  - `failure_type=active_skip`
  - `reason_code=HB_AUTO_ACTIVE_SKIP`

## Tests
- updated `agent-manager/scripts/tests/test_heartbeat_recovery.py`
  - preflight detects pane-change as active
  - preflight keeps idle when pane stable
  - auto mode skip still works for classic busy state (`HB_AUTO_BUSY_SKIP`)
  - auto mode skip works for pane-activity state (`HB_AUTO_ACTIVE_SKIP`)
- verified:
  - `python3 -m unittest -v agent-manager/scripts/tests/test_heartbeat_recovery.py`
  - `python3 -m unittest -v agent-manager/scripts/tests/test_heartbeat_session_mode.py agent-manager/scripts/tests/test_integration_cli_flow.py`

Closes #84
