### PR TITLE
Fix tmux detection when service PATH is restricted

### DIFF
--- a/agent-manager/scripts/tests/test_tmux_path_resolution.py
+++ b/agent-manager/scripts/tests/test_tmux_path_resolution.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import tmux_helper  # noqa: E402
+
+
+class TmuxPathResolutionTests(unittest.TestCase):
+    @patch("tmux_helper.shutil.which", return_value="/usr/bin/tmux")
+    def test_ensure_tmux_in_path_when_already_resolvable(self, _mock_which):
+        original_path = os.environ.get("PATH", "")
+        with patch.dict(os.environ, {"PATH": original_path}, clear=False):
+            self.assertTrue(tmux_helper._ensure_tmux_in_path())
+            self.assertEqual(os.environ.get("PATH", ""), original_path)
+
+    @patch("tmux_helper.os.access", return_value=True)
+    @patch("tmux_helper.os.path.isfile", side_effect=lambda p: p == "/opt/homebrew/bin/tmux")
+    @patch("tmux_helper.shutil.which", return_value=None)
+    def test_ensure_tmux_in_path_adds_homebrew_path_when_missing(self, _mock_which, _mock_isfile, _mock_access):
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
+            self.assertTrue(tmux_helper._ensure_tmux_in_path())
+            self.assertTrue(os.environ.get("PATH", "").startswith("/opt/homebrew/bin:"))
+
+    @patch("tmux_helper.os.access", return_value=False)
+    @patch("tmux_helper.os.path.isfile", return_value=False)
+    @patch("tmux_helper.shutil.which", return_value=None)
+    def test_ensure_tmux_in_path_returns_false_when_no_candidate(self, _mock_which, _mock_isfile, _mock_access):
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
+            self.assertFalse(tmux_helper._ensure_tmux_in_path())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-manager/scripts/tmux_helper.py
+++ b/agent-manager/scripts/tmux_helper.py
@@ -10,6 +10,7 @@ import subprocess
 import time
 import re
 import os
+import shutil
 from typing import Optional, List, Dict, Any, Tuple
 
 from runtime_state import (
@@ -30,6 +31,37 @@ GROUP_SESSION_ENV_VAR = "AGENT_MANAGER_TMUX_GROUP_SESSION"
 
 def get_group_session_name() -> str:
     return os.environ.get(GROUP_SESSION_ENV_VAR, DEFAULT_GROUP_SESSION_NAME)
+
+
+def _ensure_tmux_in_path() -> bool:
+    """Ensure `tmux` is resolvable even in restricted service environments."""
+    if shutil.which("tmux"):
+        return True
+
+    candidates = [
+        os.environ.get("TMUX_BIN", ""),
+        "/opt/homebrew/bin/tmux",  # macOS Homebrew (Apple Silicon)
+        "/usr/local/bin/tmux",     # macOS Homebrew (Intel)
+        "/opt/local/bin/tmux",     # MacPorts
+        "/usr/bin/tmux",
+    ]
+
+    for candidate in candidates:
+        candidate = str(candidate or "").strip()
+        if not candidate:
+            continue
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            bin_dir = os.path.dirname(candidate)
+            path = os.environ.get("PATH", "")
+            path_parts = [p for p in path.split(":") if p]
+            if bin_dir not in path_parts:
+                os.environ["PATH"] = f"{bin_dir}:{path}" if path else bin_dir
+            return True
+    return False
+
+
+# Try once at import-time so all subprocess(['tmux', ...]) calls can resolve.
+_ensure_tmux_in_path()
 
 
 def _is_main_agent_id(agent_id: str) -> bool:
@@ -136,8 +168,7 @@ def check_tmux() -> bool:
     Returns:
         True if tmux is installed and accessible
     """
-    result = subprocess.run(['which', 'tmux'], capture_output=True)
-    return result.returncode == 0
+    return _ensure_tmux_in_path() and shutil.which("tmux") is not None
 
 
 def list_sessions() -> List[str]:


### PR DESCRIPTION
## Summary
- add tmux path auto-discovery for restricted service environments (e.g. launchd/systemd PATH without Homebrew bin)
- keep existing behavior when `tmux` is already resolvable via PATH
- add focused unit tests for path fallback behavior

## Why
In service-managed runs (Telegram -> FractalBot -> agent-manager), `PATH` may be limited to system defaults and not include Homebrew locations. That can cause false negatives like:

- `❌ tmux is not installed`

on machines where tmux is actually installed at `/opt/homebrew/bin/tmux`.

## Changes
- `agent-manager/scripts/tmux_helper.py`
  - add `_ensure_tmux_in_path()` helper
  - fallback candidates: `TMUX_BIN`, `/opt/homebrew/bin/tmux`, `/usr/local/bin/tmux`, `/opt/local/bin/tmux`, `/usr/bin/tmux`
  - prepend discovered bin dir to process `PATH`
  - update `check_tmux()` to use fallback logic
- `agent-manager/scripts/tests/test_tmux_path_resolution.py`
  - add tests for:
    - already resolvable tmux
    - Homebrew fallback path injection
    - no candidate found

## Validation
- `python3 -m unittest agent-manager.scripts.tests.test_tmux_path_resolution -v`
- `python3 -m unittest agent-manager.scripts.tests.test_doctor_command -v`
