### PR TITLE
fix: correct nested dict and list parsing in stdlib YAML parser

### DIFF
--- a/agent-manager/scripts/agent_config.py
+++ b/agent-manager/scripts/agent_config.py
@@ -114,19 +114,27 @@ def _parse_yaml_list(list_str: str) -> List[Any]:
     return [_parse_yaml_value(item) for item in items if item]
 
 
-def _parse_yaml_dict(lines: List[str], indent_level: int = 0) -> Dict[str, Any]:
+def _parse_yaml_dict(lines: List[str], indent_level: int = 0, base_indent: Optional[int] = None) -> Dict[str, Any]:
     """
     Parse YAML dict from lines, handling nested structures via indentation.
 
     Args:
         lines: List of YAML lines (without --- markers)
-        indent_level: Current indentation level for nested structures
+        indent_level: Current nesting depth (0 for root level)
+        base_indent: Base indentation for this level (auto-detected if None)
 
     Returns:
         Parsed dictionary
     """
     result = {}
     i = 0
+
+    # Auto-detect base indentation from first non-empty line
+    if base_indent is None:
+        for line in lines:
+            if line.strip():
+                base_indent = len(line) - len(line.lstrip())
+                break
 
     while i < len(lines):
         line = lines[i]
@@ -140,32 +148,13 @@ def _parse_yaml_dict(lines: List[str], indent_level: int = 0) -> Dict[str, Any]:
         stripped = line.lstrip()
         current_indent = len(line) - len(stripped)
 
-        # End of current dict level (less indented or same level but we're nested)
-        if current_indent < indent_level:
+        # End of current dict level (less indented than base)
+        if current_indent < base_indent:
             break
 
-        # Check for nested dict (more indented)
-        if current_indent > indent_level:
-            # Collect all lines at this indentation level
-            nested_lines = [lines[i]]
+        # Skip lines that are more indented than base (handled separately)
+        if current_indent > base_indent:
             i += 1
-            while i < len(lines):
-                next_line = lines[i]
-                if not next_line.strip():
-                    nested_lines.append(next_line)
-                    i += 1
-                    continue
-                next_indent = len(next_line) - len(next_line.lstrip())
-                if next_indent <= indent_level:
-                    break
-                nested_lines.append(next_line)
-                i += 1
-
-            # Parse nested dict and assign to last key
-            if result:
-                last_key = list(result.keys())[-1]
-                nested_dict = _parse_yaml_dict(nested_lines, current_indent)
-                result[last_key] = nested_dict
             continue
 
         # Parse key: value pair
@@ -182,29 +171,56 @@ def _parse_yaml_dict(lines: List[str], indent_level: int = 0) -> Dict[str, Any]:
                 i += 1
                 if i < len(lines):
                     next_line = lines[i]
-                    next_indent = len(next_line) - len(next_line.lstrip()) if next_line.strip() else 0
+                    if next_line.strip():
+                        next_indent = len(next_line) - len(next_line.lstrip())
 
-                    if next_indent > indent_level:
-                        # Nested dict
-                        nested_lines = [next_line]
-                        i += 1
-                        while i < len(lines):
-                            next_line = lines[i]
-                            if not next_line.strip():
-                                nested_lines.append(next_line)
-                                i += 1
+                        if next_indent > base_indent:
+                            # Check if nested content is a list (starts with '-')
+                            next_stripped = next_line.lstrip()
+                            if next_stripped.startswith('- '):
+                                # Parse as list
+                                list_items = []
+                                while i < len(lines):
+                                    next_line = lines[i]
+                                    if not next_line.strip():
+                                        i += 1
+                                        continue
+                                    item_indent = len(next_line) - len(next_line.lstrip())
+                                    if item_indent < base_indent:
+                                        break
+                                    stripped_item = next_line.lstrip()
+                                    if stripped_item.startswith('- '):
+                                        list_items.append(stripped_item[2:].strip())
+                                    else:
+                                        break
+                                    i += 1
+
+                                result[key] = [_parse_yaml_value(item) for item in list_items]
                                 continue
-                            next_indent2 = len(next_line) - len(next_line.lstrip())
-                            if next_indent2 <= indent_level:
-                                break
-                            nested_lines.append(next_line)
-                            i += 1
+                            else:
+                                # Parse as nested dict
+                                nested_lines = []
+                                while i < len(lines):
+                                    next_line = lines[i]
+                                    if not next_line.strip():
+                                        nested_lines.append(next_line)
+                                        i += 1
+                                        continue
+                                    next_indent2 = len(next_line) - len(next_line.lstrip())
+                                    if next_indent2 <= base_indent:
+                                        break
+                                    nested_lines.append(next_line)
+                                    i += 1
 
-                        result[key] = _parse_yaml_dict(nested_lines, current_indent)
-                        continue
-
-                # Empty value
-                result[key] = None
+                                # Parse nested dict with new base_indent
+                                result[key] = _parse_yaml_dict(nested_lines, indent_level + 1, next_indent)
+                                continue
+                        else:
+                            # No nested content, empty value
+                            result[key] = None
+                    else:
+                        # No nested content, empty value
+                        result[key] = None
         else:
             # Malformed line, skip
             pass


### PR DESCRIPTION
## Problem

The stdlib YAML parser introduced in PR #96 had a critical bug where:
- Nested dictionaries (like `heartbeat`) were parsed as `{}`
- Lists (like `launcher_args` and `skills`) were parsed as `{}`

This caused heartbeat to fail with `No heartbeat configured for agent 'main'` because the heartbeat config returned an empty dict.

## Root Cause

In `_parse_yaml_dict`, the `indent_level` logic was incorrect:
- When parsing `heartbeat:` followed by 2-space indented content
- The check `current_indent > indent_level` (2 > 0) would skip nested content
- Or when calling `_parse_yaml_dict(nested_lines, current_indent)` with `indent_level=2`
- All lines with indent=2 would satisfy `current_indent <= indent_level` and be skipped

## Solution

Rewrote `_parse_yaml_dict` to use `base_indent` parameter:
- `base_indent`: the indentation of the current level (auto-detected from first line)
- Lines with `current_indent > base_indent` are now handled correctly
- Added proper YAML list item (`- item`) support
- Distinguish between list items and dict nested content

## Testing

✅ All 178 unit tests pass
✅ heartbeat config parses correctly
✅ lists (launcher_args, skills) parse correctly
✅ `heartbeat run main` command works

## Related

- Regression from #96 (Remove PyYAML dependency)
- Fixes 14:50 heartbeat failure