### PR TITLE
fix: validate Codex cwd for non-main session restore

### DIFF
--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -350,14 +350,14 @@ def _codex_session_file_for_id(session_id: str) -> Optional[Path]:
 
 
 def _codex_session_matches_owner(jsonl_path: Path, *, cwd: str, agent_id: str) -> bool:
-    if not _should_enforce_codex_session_owner(agent_id):
-        return True
     meta = _read_codex_session_meta(jsonl_path)
     if not meta:
         return False
     expected_cwd = _normalize_path(cwd)
     if meta.get('cwd') != expected_cwd:
         return False
+    if not _should_enforce_codex_session_owner(agent_id):
+        return True
     marker = _codex_session_owner_marker(agent_id)
     return marker in str(meta.get('base_instructions') or '')
 
@@ -368,7 +368,7 @@ def _codex_session_exists(cwd: str, session_id: str, *, agent_id: str = '') -> b
     session_file = _codex_session_file_for_id(session_id)
     if session_file is None:
         return False
-    if agent_id and _should_enforce_codex_session_owner(agent_id):
+    if agent_id:
         return _codex_session_matches_owner(session_file, cwd=cwd, agent_id=agent_id)
     return True
 

--- a/agent-manager/scripts/tests/test_provider_restore.py
+++ b/agent-manager/scripts/tests/test_provider_restore.py
@@ -69,6 +69,40 @@ class ProviderRestoreTests(unittest.TestCase):
 
             self.assertEqual(session_id, good_id)
 
+    def test_find_new_codex_session_id_filters_by_cwd_for_non_main(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sessions_root = Path(tmpdir)
+            target_cwd = "/home/elliot245/work-assistant-a"
+            other_cwd = "/home/elliot245/work-assistant-b"
+            agent_id = "emp-0002"
+            good_id = "019c3eb0-bca0-7ab0-8b93-3b54b5f582de"
+            bad_id = "019c3eb0-bca0-7ab0-8b93-3b54b5f582df"
+
+            good_file = sessions_root / f"rollout-good-{good_id}.jsonl"
+            good_file.write_text(
+                '{"type":"session_meta","payload":{"id":"%s","cwd":"%s","base_instructions":{"text":"coder prompt"}}}\n'
+                % (good_id, target_cwd),
+                encoding="utf-8",
+            )
+
+            bad_file = sessions_root / f"rollout-bad-{bad_id}.jsonl"
+            bad_file.write_text(
+                '{"type":"session_meta","payload":{"id":"%s","cwd":"%s","base_instructions":{"text":"other cwd"}}}\n'
+                % (bad_id, other_cwd),
+                encoding="utf-8",
+            )
+            os.utime(good_file, (1, 1))
+            os.utime(bad_file, (2, 2))
+
+            with patch("main._codex_sessions_dir", return_value=sessions_root):
+                session_id = main._find_new_codex_session_id(
+                    target_cwd,
+                    before_jsonl_paths=set(),
+                    agent_id=agent_id,
+                )
+
+            self.assertEqual(session_id, good_id)
+
     def test_codex_session_exists_rejects_wrong_owner(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             sessions_root = Path(tmpdir)
@@ -85,6 +119,26 @@ class ProviderRestoreTests(unittest.TestCase):
                     "/home/elliot245/work-assistant",
                     session_id,
                     agent_id="main",
+                )
+
+            self.assertFalse(ok)
+
+    def test_codex_session_exists_rejects_wrong_cwd_for_non_main(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sessions_root = Path(tmpdir)
+            session_id = "019c3eb0-bca0-7ab0-8b93-3b54b5f582e0"
+            session_file = sessions_root / f"rollout-{session_id}.jsonl"
+            session_file.write_text(
+                '{"type":"session_meta","payload":{"id":"%s","cwd":"/home/elliot245/work-assistant-b","base_instructions":{"text":"other owner"}}}\n'
+                % session_id,
+                encoding="utf-8",
+            )
+
+            with patch("main._codex_sessions_dir", return_value=sessions_root):
+                ok = main._codex_session_exists(
+                    "/home/elliot245/work-assistant-a",
+                    session_id,
+                    agent_id="emp-0002",
                 )
 
             self.assertFalse(ok)


### PR DESCRIPTION
## Summary
This fixes Codex provider-session restore for non-main agents so cached session ids must match the normalized working directory before they are considered reusable.

## Problem
Non-main agents currently skip cwd validation in the Codex restore path, so a stale cached `session_id` from another worktree can be accepted during restore/reconnect.

## Changes
- require `_codex_session_matches_owner()` to read session metadata and verify normalized `cwd` for every agent
- keep the stricter owner-marker requirement for `main` on top of cwd matching
- make `_codex_session_exists()` use the same validation path for any `agent_id`
- add regression tests for non-main wrong-cwd rejection and correct session selection by cwd

## Verification
- `python3 agent-manager/scripts/tests/test_provider_restore.py`
- `python3 agent-manager/scripts/tests/test_main_agent_support.py`

Closes #112.