### PR TITLE
feat: add heartbeat timer rescue flow

### DIFF
--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -428,6 +428,7 @@ heartbeat:
 | `max_runtime` | string | | Maximum runtime (e.g., `5m`, `10m`) |
 | `session_mode` | string | | Session policy: `restore` (default), `auto` (rollover when context <25%), `fresh` (always rollover after handoff) |
 | `mode` | string | | Heartbeat trigger mode: `normal` (default cron only) or `full_speed` (Codex Stop hook schedules `start --restore` + `heartbeat run` 5s after a real stop event) |
+| `auto_starvation_skip_threshold` | int | | `auto` mode only. Default `3`; set `0` to disable the forced-dispatch starvation bypass after consecutive preflight skips |
 | `enabled` | bool | | Default: `true` |
 
 `full_speed` is currently only supported for `launcher: codex`. It uses a stable Codex `Stop` hook that reads the latest heartbeat config at stop time. The first time you add this managed hook to an already-running session, you still need one fresh start so Codex loads the hook; after that, switching `normal`/`full_speed` does not require restarting the session.

--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -415,6 +415,7 @@ heartbeat:
   cron: "*/30 * * * *"  # Every 30 minutes
   max_runtime: 5m
   session_mode: auto     # restore | auto | fresh
+  mode: full_speed       # normal | full_speed
   enabled: true
 ---
 ```
@@ -426,7 +427,10 @@ heartbeat:
 | `cron` | string | ✓ | Cron expression (e.g., `*/30 * * * *`) |
 | `max_runtime` | string | | Maximum runtime (e.g., `5m`, `10m`) |
 | `session_mode` | string | | Session policy: `restore` (default), `auto` (rollover when context <25%), `fresh` (always rollover after handoff) |
+| `mode` | string | | Heartbeat trigger mode: `normal` (default cron only) or `full_speed` (Codex Stop hook schedules `start --restore` + `heartbeat run` 5s after a real stop event) |
 | `enabled` | bool | | Default: `true` |
+
+`full_speed` is currently only supported for `launcher: codex`. It uses a stable Codex `Stop` hook that reads the latest heartbeat config at stop time. The first time you add this managed hook to an already-running session, you still need one fresh start so Codex loads the hook; after that, switching `normal`/`full_speed` does not require restarting the session.
 
 ### Heartbeat vs Schedules
 
@@ -450,7 +454,7 @@ Output:
 💓 Heartbeats:
 
 dev (EMP_0001):
-  ✓ heartbeat           */30 * * * *         (5m mode:auto)
+  ✓ heartbeat           */30 * * * *         (5m session:auto heartbeat:full_speed)
 ```
 
 #### `heartbeat sync` - Sync Heartbeats to Crontab
@@ -491,6 +495,24 @@ $CLI heartbeat run EMP_0001 --timeout 1m
 - Sends standard heartbeat message to the agent
 - Optional session rollover via `session_mode` (handoff first, then fresh session)
 - Waits for response (up to `max_runtime`)
+- If `mode: full_speed` is enabled on Codex, a Stop hook schedules one background recovery pass (`start --restore` + `heartbeat run`) 5 seconds after the agent really stops
+
+Note: the old Codex Stop-hook implementation for `full_speed` has been retired because Codex `Stop` events also fire on normal turn completion. Use the `timer` command for timer-driven follow-up heartbeats instead.
+
+### `timer` - Schedule Delayed Actions
+
+Use `timer` for one-shot delayed actions without cron:
+
+```bash
+# Run one heartbeat in 5 seconds
+$CLI timer heartbeat main --delay 5s
+
+# Run an arbitrary agent-manager command in 5 seconds
+$CLI timer command --delay 5s -- heartbeat run main --timeout 8m
+
+# Inspect recent timers
+$CLI timer list
+```
 
 ### `timer` - Schedule Delayed Actions
 

--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -415,7 +415,7 @@ heartbeat:
   cron: "*/30 * * * *"  # Every 30 minutes
   max_runtime: 5m
   session_mode: auto     # restore | auto | fresh
-  mode: full_speed       # normal | full_speed
+  mode: normal           # normal (use `timer` for delayed rescue; `full_speed` is legacy)
   enabled: true
 ---
 ```
@@ -427,11 +427,11 @@ heartbeat:
 | `cron` | string | ✓ | Cron expression (e.g., `*/30 * * * *`) |
 | `max_runtime` | string | | Maximum runtime (e.g., `5m`, `10m`) |
 | `session_mode` | string | | Session policy: `restore` (default), `auto` (rollover when context <25%), `fresh` (always rollover after handoff) |
-| `mode` | string | | Heartbeat trigger mode: `normal` (default cron only) or `full_speed` (Codex Stop hook schedules `start --restore` + `heartbeat run` 5s after a real stop event) |
+| `mode` | string | | Heartbeat trigger mode. `normal` is the only active path. `full_speed` is a deprecated compatibility value that only preserves legacy Codex hook cleanup/readback during `start`; timer-driven follow-up is the supported replacement. |
 | `auto_starvation_skip_threshold` | int | | `auto` mode only. Default `3`; set `0` to disable the forced-dispatch starvation bypass after consecutive preflight skips |
 | `enabled` | bool | | Default: `true` |
 
-`full_speed` is currently only supported for `launcher: codex`. It uses a stable Codex `Stop` hook that reads the latest heartbeat config at stop time. The first time you add this managed hook to an already-running session, you still need one fresh start so Codex loads the hook; after that, switching `normal`/`full_speed` does not require restarting the session.
+`full_speed` should now be treated as a legacy compatibility marker, not a canonical execution path. If an older Codex Stop hook is still present, `start` will clean it up; new delayed follow-up / rescue flows should use `timer`.
 
 ### Heartbeat vs Schedules
 
@@ -455,7 +455,7 @@ Output:
 💓 Heartbeats:
 
 dev (EMP_0001):
-  ✓ heartbeat           */30 * * * *         (5m session:auto heartbeat:full_speed)
+  ✓ heartbeat           */30 * * * *         (5m session:auto)
 ```
 
 #### `heartbeat sync` - Sync Heartbeats to Crontab
@@ -496,9 +496,7 @@ $CLI heartbeat run EMP_0001 --timeout 1m
 - Sends standard heartbeat message to the agent
 - Optional session rollover via `session_mode` (handoff first, then fresh session)
 - Waits for response (up to `max_runtime`)
-- If `mode: full_speed` is enabled on Codex, a Stop hook schedules one background recovery pass (`start --restore` + `heartbeat run`) 5 seconds after the agent really stops
-
-Note: the old Codex Stop-hook implementation for `full_speed` has been retired because Codex `Stop` events also fire on normal turn completion. Use the `timer` command for timer-driven follow-up heartbeats instead.
+- In `auto` mode, stale pending heartbeats can schedule or trigger rescue via the timer-backed recovery path
 
 ### `timer` - Schedule Delayed Actions
 
@@ -508,20 +506,8 @@ Use `timer` for one-shot delayed actions without cron:
 # Run one heartbeat in 5 seconds
 $CLI timer heartbeat main --delay 5s
 
-# Run an arbitrary agent-manager command in 5 seconds
-$CLI timer command --delay 5s -- heartbeat run main --timeout 8m
-
-# Inspect recent timers
-$CLI timer list
-```
-
-### `timer` - Schedule Delayed Actions
-
-Use `timer` for one-shot delayed actions without cron:
-
-```bash
-# Run one heartbeat in 5 seconds
-$CLI timer heartbeat main --delay 5s
+# Schedule one heartbeat rescue in 5 seconds
+$CLI timer rescue main --delay 5s --timeout 8m --reason auto_pending_heartbeat_rescue
 
 # Run an arbitrary agent-manager command in 5 seconds
 $CLI timer command --delay 5s -- heartbeat run main --timeout 8m

--- a/agent-manager/rules/heartbeat.md
+++ b/agent-manager/rules/heartbeat.md
@@ -1,0 +1,24 @@
+# agent-manager / heartbeat rules
+
+仅在当前 heartbeat 需要推进 `agent-manager-skill` 相关 OKR 时读取本文件。
+
+## 目标范围
+- `fractalmind-ai/agent-manager-skill` 的 Phase 2 / inbound queue / replay / rescue-sweep / heartbeat 相关工作
+- 只补 skill-specific 规则；全局升级、审批、静默窗口仍以根级 `HEARTBEAT.md` 为准
+
+## 心跳执行规则
+1. 先 `cd projects/fractalmind-ai/agent-manager-skill`
+2. 先核对 **当前 canonical tracker**，不要直接复用旧 issue 编号：
+   - `gh issue list -R fractalmind-ai/agent-manager-skill --state open`
+   - `gh pr list -R fractalmind-ai/agent-manager-skill --state open`
+3. `#138 / #141 / PR #142` 现在都只算**历史证据**；若 heartbeat 里仍把它们写成当前 tracker，必须先纠偏再汇报
+4. 若现有 Phase 2 切片都已 merge/closed，则先判断：
+   - 是 Phase 2 已实质收口，可转 COMPLETE / observe
+   - 还是出现了新的剩余缺口，需要**新建 issue** 继续追踪
+5. 汇报必须给出可复核证据：issue/PR URL、commit、测试命令、tmux/CLI 输出、文件路径
+6. routine review/merge gate 继续 owner 推进；只有触发根级 `HEARTBEAT.md` 的审批项 / 卡点条件时，才升级给 Elliot
+
+## 当前已知提醒（2026-03-20）
+- `Issue #141` 已 closed，不能再当作当前 freshest tracker
+- open issue 当前主要是 `#117 / #114 / #109`；是否与 Phase 2 直接相关，需每轮 fresh 判断
+- 如果本轮只是做 HEARTBEAT / memory 重构，先把 tracker 口径纠偏，再决定是否继续追 agent-manager 代码线

--- a/agent-manager/scripts/agent_config.py
+++ b/agent-manager/scripts/agent_config.py
@@ -996,6 +996,7 @@ def list_all_heartbeats(agents_dir: Optional[Path] = None) -> List[Dict[str, Any
             'cron': heartbeat.get('cron', ''),
             'max_runtime': heartbeat.get('max_runtime', ''),
             'session_mode': heartbeat.get('session_mode', 'restore'),
+            'mode': heartbeat.get('mode', 'normal'),
             'enabled': heartbeat.get('enabled', True),
             'schedule': heartbeat.get('schedule'),
         })

--- a/agent-manager/scripts/cli_parser.py
+++ b/agent-manager/scripts/cli_parser.py
@@ -148,6 +148,26 @@ Examples:
         '--notifier-channel',
         help='Notifier channel when --notify-on-failure is enabled (default: all)',
     )
+    heartbeat_run_parser.add_argument(
+        '--force-session-mode',
+        choices=['restore', 'auto', 'fresh', 'force'],
+        help=argparse.SUPPRESS,
+    )
+
+    heartbeat_rescue_parser = heartbeat_subparsers.add_parser('rescue', help='Force-stop/start one agent heartbeat session')
+    heartbeat_rescue_parser.add_argument('agent', help='Agent name or file ID')
+    heartbeat_rescue_parser.add_argument('--timeout', '-t', help='Override heartbeat timeout for the post-rescue prime pass')
+    heartbeat_rescue_parser.add_argument('--reason', help='Operator note for why the rescue is being performed')
+    heartbeat_rescue_parser.add_argument(
+        '--no-prime',
+        action='store_true',
+        help='Restart the agent session but skip the immediate heartbeat prime pass',
+    )
+    heartbeat_rescue_parser.add_argument(
+        '--fresh',
+        action='store_true',
+        help='Use a fresh restart instead of restore mode',
+    )
 
     heartbeat_trace_parser = heartbeat_subparsers.add_parser('trace', help='Query heartbeat audit trace logs')
     heartbeat_trace_parser.add_argument('--hb-id', help='Filter by heartbeat id (HB_ID)')
@@ -188,6 +208,24 @@ Examples:
     timer_heartbeat_parser.add_argument('agent', help='Agent name or file ID')
     timer_heartbeat_parser.add_argument('--delay', '-d', required=True, help='Delay before running (e.g., 5s, 30s, 5m)')
     timer_heartbeat_parser.add_argument('--timeout', '-t', help='Override heartbeat timeout')
+
+    timer_rescue_parser = timer_subparsers.add_parser('rescue', help='Run one heartbeat rescue after a delay')
+    timer_rescue_parser.add_argument('agent', help='Agent name or file ID')
+    timer_rescue_parser.add_argument('--delay', '-d', required=True, help='Delay before running (e.g., 5s, 30s, 5m)')
+    timer_rescue_parser.add_argument('--timeout', '-t', help='Override heartbeat timeout for the prime pass')
+    timer_rescue_parser.add_argument('--reason', help='Operator note for why the rescue is being scheduled')
+    timer_rescue_parser.add_argument(
+        '--no-prime',
+        action='store_true',
+        help='Restart the agent session but skip the immediate heartbeat prime pass',
+    )
+    timer_rescue_parser.add_argument(
+        '--fresh',
+        action='store_true',
+        help='Use a fresh restart instead of restore mode',
+    )
+    timer_rescue_parser.add_argument('--heartbeat-id', help=argparse.SUPPRESS)
+    timer_rescue_parser.add_argument('--dedupe-key', help=argparse.SUPPRESS)
 
     timer_command_parser = timer_subparsers.add_parser('command', help='Run one agent-manager command after a delay')
     timer_command_parser.add_argument('--delay', '-d', required=True, help='Delay before running (e.g., 5s, 30s, 5m)')

--- a/agent-manager/scripts/commands/heartbeat.py
+++ b/agent-manager/scripts/commands/heartbeat.py
@@ -6,6 +6,7 @@ def cmd_heartbeat(
     args,
     *,
     run_handler: Callable,
+    rescue_handler: Callable,
     trace_handler: Callable,
     slo_handler: Callable,
 ):
@@ -44,6 +45,9 @@ def cmd_heartbeat(
 
     if args.heartbeat_command == 'run':
         return run_handler(args)
+
+    if args.heartbeat_command == 'rescue':
+        return rescue_handler(args)
 
     if args.heartbeat_command == 'trace':
         return trace_handler(args)

--- a/agent-manager/scripts/commands/lifecycle.py
+++ b/agent-manager/scripts/commands/lifecycle.py
@@ -284,6 +284,26 @@ def cmd_start(args, *, deps: Any):
         print(f"   To enable: Set 'enabled: true' in the agent config")
         return 1
 
+    working_dir = args.working_dir or agent_config.get('working_directory')
+    normalized_working_dir = normalize_path(working_dir) if working_dir else ""
+    repo_root = get_repo_root()
+    sync_fullspeed_hook = getattr(deps, '_sync_codex_fullspeed_stop_hook', None)
+    hook_sync = None
+    if normalized_working_dir and callable(sync_fullspeed_hook):
+        try:
+            hook_sync = sync_fullspeed_hook(
+                agent_config,
+                working_dir=normalized_working_dir,
+                repo_root=repo_root,
+            )
+        except ValueError as exc:
+            print(f"❌ {exc}")
+            return 1
+        if hook_sync.get('reason') == 'unsupported_provider':
+            print("⚠️  heartbeat.mode=full_speed currently only supports launcher: codex")
+        elif hook_sync.get('reason') == 'cleaned' and hook_sync.get('updated'):
+            print(f"ℹ️  Removed deprecated Codex full-speed Stop hook: {hook_sync.get('hooks_path', '')}")
+
     if session_exists(agent_id):
         session_info = get_session_info(agent_id) or {}
         session_name = session_info.get('session', _session_label(agent_id))
@@ -314,14 +334,11 @@ def cmd_start(args, *, deps: Any):
         print(f"   Or restore (reuse existing): python3 {_script_name(deps)} start {agent_file_id} --restore")
         return 1
 
-    working_dir = args.working_dir or agent_config.get('working_directory')
-    if not working_dir:
+    if not normalized_working_dir:
         print("❌ No working directory specified")
         return 1
 
-    working_dir = normalize_path(working_dir)
-
-    repo_root = get_repo_root()
+    working_dir = normalized_working_dir
     skills_dir = repo_root / '.agent' / 'skills'
 
     launcher = resolve_launcher_command(agent_config.get('launcher', ''))

--- a/agent-manager/scripts/commands/timer.py
+++ b/agent-manager/scripts/commands/timer.py
@@ -31,6 +31,29 @@ def _read_json(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding='utf-8'))
 
 
+def _find_existing_timer(*, repo_root: Path, kind: str, dedupe_key: str) -> dict[str, object] | None:
+    if not dedupe_key:
+        return None
+
+    timer_dir = _timer_state_dir(repo_root)
+    if not timer_dir.exists():
+        return None
+
+    for timer_file in sorted(timer_dir.glob('*.json')):
+        try:
+            payload = _read_json(timer_file)
+        except Exception:
+            continue
+        if str(payload.get('kind') or '') != kind:
+            continue
+        if str(payload.get('dedupe_key') or '') != dedupe_key:
+            continue
+        if str(payload.get('status') or '') not in {'pending', 'running'}:
+            continue
+        return payload
+    return None
+
+
 def _schedule_worker(*, repo_root: Path, timer_file: Path, log_file: Path) -> int:
     worker_script = _timer_worker_script()
     log_file.parent.mkdir(parents=True, exist_ok=True)
@@ -62,6 +85,15 @@ def _schedule_timer(*, args, deps: Any, kind: str, payload: dict[str, object]) -
         return 1
 
     repo_root = deps.get_repo_root()
+    dedupe_key = str(payload.get('dedupe_key') or '').strip()
+    if dedupe_key:
+        existing = _find_existing_timer(repo_root=repo_root, kind=kind, dedupe_key=dedupe_key)
+        if existing is not None:
+            print(f"⏱️  Timer already scheduled: {existing.get('timer_id')}")
+            print(f"   Kind: {kind}")
+            print(f"   Dedupe key: {dedupe_key}")
+            return 0
+
     timer_id = _create_timer_id(kind)
     now = int(time.time())
     run_at = now + int(delay_seconds)
@@ -144,6 +176,22 @@ def cmd_timer(args, *, deps: Any):
             payload={
                 'agent': args.agent,
                 'timeout': str(args.timeout or '').strip(),
+            },
+        )
+
+    if args.timer_command == 'rescue':
+        return _schedule_timer(
+            args=args,
+            deps=deps,
+            kind='rescue',
+            payload={
+                'agent': args.agent,
+                'timeout': str(args.timeout or '').strip(),
+                'prime': not bool(getattr(args, 'no_prime', False)),
+                'fresh': bool(getattr(args, 'fresh', False)),
+                'reason': str(getattr(args, 'reason', '') or '').strip(),
+                'heartbeat_id': str(getattr(args, 'heartbeat_id', '') or '').strip(),
+                'dedupe_key': str(getattr(args, 'dedupe_key', '') or '').strip(),
             },
         )
 

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -1913,6 +1913,7 @@ def cmd_heartbeat(args):
     return heartbeat_cmd_heartbeat(
         args,
         run_handler=cmd_heartbeat_run,
+        rescue_handler=cmd_heartbeat_rescue,
         trace_handler=cmd_heartbeat_trace,
         slo_handler=cmd_heartbeat_slo,
     )
@@ -2086,6 +2087,62 @@ def cmd_dream_run(args):
     return 1
 
 
+def cmd_heartbeat_rescue(args):
+    """Force-stop/start one heartbeat session and optionally prime it."""
+    if not check_tmux():
+        print("❌ tmux is not installed")
+        return 1
+
+    agent_config = resolve_agent(args.agent)
+    if not agent_config:
+        print(f"❌ Agent '{args.agent}' not found")
+        return 1
+
+    agent_name = agent_config['name']
+    agent_file_id = agent_config['file_id']
+    agent_id = get_agent_id(agent_config)
+    reason = str(getattr(args, 'reason', '') or '').strip()
+    prime = not bool(getattr(args, 'no_prime', False))
+    use_fresh = bool(getattr(args, 'fresh', False))
+
+    print(f"🛟 Heartbeat rescue: {agent_name}")
+    if reason:
+        print(f"   Reason: {reason}")
+    print(f"   Prime after restart: {'yes' if prime else 'no'}")
+    print(f"   Restart mode: {'fresh' if use_fresh else 'restore'}")
+
+    if use_fresh:
+        restarted = _restart_heartbeat_session_fresh(
+            agent_file_id,
+            agent_name,
+            agent_id,
+            deps=_lifecycle_deps_module(),
+        )
+    else:
+        restarted = _restart_heartbeat_session_restore(agent_file_id, agent_name, agent_id)
+    if not restarted:
+        return 1
+
+    if not prime:
+        print("✅ Heartbeat rescue completed (prime skipped)")
+        return 0
+
+    prime_args = argparse.Namespace(
+        agent=agent_file_id,
+        timeout=getattr(args, 'timeout', None),
+        retry=0,
+        backoff_seconds=0,
+        fallback_mode='none',
+        notify_on_failure=False,
+        notifier_channel=None,
+        force_session_mode='force',
+    )
+    prime_result = cmd_heartbeat_run(prime_args)
+    if prime_result == 0:
+        print("✅ Heartbeat rescue completed and prime pass succeeded")
+    return prime_result
+
+
 def cmd_heartbeat_run(args):
     """Run a heartbeat check for an agent."""
     if not check_tmux():
@@ -2237,63 +2294,111 @@ def cmd_heartbeat_run(args):
         if preflight_state in {'busy', 'stuck', 'blocked', 'error'}:
             skip_failure_type = 'busy_skip'
             skip_reason_code = 'HB_AUTO_BUSY_SKIP'
+            skip_recovery_action = 'skip_busy'
             if preflight_state == 'busy' and str(preflight_reason).startswith('preflight_pane_changed:'):
                 skip_failure_type = 'active_skip'
                 skip_reason_code = 'HB_AUTO_ACTIVE_SKIP'
             elif preflight_state == 'busy' and str(preflight_reason).startswith('pending_heartbeat:'):
                 skip_failure_type = 'pending_skip'
                 skip_reason_code = 'HB_AUTO_PENDING_SKIP'
-            starvation_guard_armed = skip_reason_code != 'HB_AUTO_PENDING_SKIP'
-            consecutive_skip_count = 0
-            if starvation_guard_armed:
-                consecutive_skip_count = _count_consecutive_auto_preflight_skips(
+                pending_hb_id = _parse_pending_heartbeat_reason(preflight_reason)
+                pending_age_seconds = _heartbeat_id_age_seconds(pending_hb_id)
+                pending_skip_count = _count_consecutive_auto_preflight_skips(
                     repo_root,
                     agent_id=agent_id,
+                    reason_codes={'HB_AUTO_PENDING_SKIP'},
                 )
-                if consecutive_skip_count >= _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD:
-                    recovery_action = 'auto_starvation_bypass'
-                    print(
-                        "⚠️  Auto-mode starvation guard triggered after "
-                        f"{consecutive_skip_count} consecutive preflight skips; "
-                        "dispatching one heartbeat attempt anyway"
+                should_rescue_pending = (
+                    (pending_age_seconds is not None and pending_age_seconds >= _HEARTBEAT_PENDING_RESCUE_AGE_SECONDS)
+                    or pending_skip_count >= _HEARTBEAT_PENDING_RESCUE_SKIP_THRESHOLD
+                )
+                if should_rescue_pending:
+                    age_desc = (
+                        f"{pending_age_seconds}s old"
+                        if pending_age_seconds is not None
+                        else 'age=unknown'
                     )
-                else:
-                    starvation_guard_armed = False
-            if not starvation_guard_armed:
-                print(
-                    "⏭️  Agent is not idle "
-                    f"(state={preflight_state}, reason={preflight_reason}); "
-                    "skipping heartbeat dispatch in auto mode to avoid batch accumulation"
-                )
-                _append_heartbeat_audit_event(
-                    repo_root,
-                    agent_id=agent_id,
-                    heartbeat_id=heartbeat_id,
-                    send_status='skip',
-                    ack_status='not_checked',
-                    duration_ms=0,
-                    context_left=context_left_percent,
-                    failure_type=skip_failure_type,
-                    session_mode=session_mode,
-                    phase='preflight',
-                    attempt=0,
-                    recovery_action='skip_busy',
-                    reason_code=skip_reason_code,
-                    ack_evidence='none',
-                )
-                _maybe_trigger_dream_from_heartbeat(
-                    repo_root=repo_root,
-                    agent_config=agent_config,
-                    agent_id=agent_id,
-                    agent_file_id=agent_file_id,
-                    heartbeat=heartbeat,
-                    heartbeat_id=heartbeat_id,
-                    heartbeat_timestamp=_utc_now_iso(),
-                    ack_status='not_checked',
-                    ack_evidence='none',
-                    failure_type=skip_failure_type,
-                )
-                return 0
+                    print(
+                        "🛟 Pending heartbeat rescue triggered "
+                        f"(hb_id={pending_hb_id or 'unknown'}, age={age_desc}, "
+                        f"consecutive_pending_skips={pending_skip_count})"
+                    )
+                    if not _restart_heartbeat_session_restore(agent_file_id, agent_name, agent_id):
+                        print("⚠️  Pending heartbeat rescue failed; falling back to skip")
+                    else:
+                        recovery_action = 'auto_pending_rescue'
+                        context_left_percent = _detect_agent_context_left_percent(agent_id, launcher=launcher)
+                        print("♻️  Pending heartbeat rescue completed; continuing current heartbeat run")
+                        preflight_state = 'idle'
+                        preflight_reason = 'auto_pending_rescue_completed'
+                elif pending_hb_id:
+                    remaining_delay = _HEARTBEAT_PENDING_RESCUE_AGE_SECONDS
+                    if pending_age_seconds is not None:
+                        remaining_delay = max(
+                            _HEARTBEAT_PENDING_RESCUE_MIN_DELAY_SECONDS,
+                            _HEARTBEAT_PENDING_RESCUE_AGE_SECONDS - pending_age_seconds,
+                        )
+                    if _schedule_pending_heartbeat_rescue_timer(
+                        agent_file_id=agent_file_id,
+                        pending_heartbeat_id=pending_hb_id,
+                        delay_seconds=remaining_delay,
+                        timeout_seconds=timeout_seconds,
+                    ):
+                        skip_recovery_action = 'schedule_pending_rescue_timer'
+            if preflight_state == 'idle':
+                pass
+            else:
+                starvation_guard_armed = skip_reason_code != 'HB_AUTO_PENDING_SKIP'
+                consecutive_skip_count = 0
+                if starvation_guard_armed:
+                    consecutive_skip_count = _count_consecutive_auto_preflight_skips(
+                        repo_root,
+                        agent_id=agent_id,
+                    )
+                    if consecutive_skip_count >= _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD:
+                        recovery_action = 'auto_starvation_bypass'
+                        print(
+                            "⚠️  Auto-mode starvation guard triggered after "
+                            f"{consecutive_skip_count} consecutive preflight skips; "
+                            "dispatching one heartbeat attempt anyway"
+                        )
+                    else:
+                        starvation_guard_armed = False
+                if not starvation_guard_armed:
+                    print(
+                        "⏭️  Agent is not idle "
+                        f"(state={preflight_state}, reason={preflight_reason}); "
+                        "skipping heartbeat dispatch in auto mode to avoid batch accumulation"
+                    )
+                    _append_heartbeat_audit_event(
+                        repo_root,
+                        agent_id=agent_id,
+                        heartbeat_id=heartbeat_id,
+                        send_status='skip',
+                        ack_status='not_checked',
+                        duration_ms=0,
+                        context_left=context_left_percent,
+                        failure_type=skip_failure_type,
+                        session_mode=session_mode,
+                        phase='preflight',
+                        attempt=0,
+                        recovery_action=skip_recovery_action,
+                        reason_code=skip_reason_code,
+                        ack_evidence='none',
+                    )
+                    _maybe_trigger_dream_from_heartbeat(
+                        repo_root=repo_root,
+                        agent_config=agent_config,
+                        agent_id=agent_id,
+                        agent_file_id=agent_file_id,
+                        heartbeat=heartbeat,
+                        heartbeat_id=heartbeat_id,
+                        heartbeat_timestamp=_utc_now_iso(),
+                        ack_status='not_checked',
+                        ack_evidence='none',
+                        failure_type=skip_failure_type,
+                    )
+                    return 0
     elif session_mode == 'force':
         print("   Force mode: bypass preflight idle check and always dispatch heartbeat")
 

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -717,6 +717,13 @@ _HEARTBEAT_TRACE_MAX_LIMIT = 5000
 _DREAM_ID_PATTERN = re.compile(r"\[DREAM_ID:([^\]\s]+)\]")
 _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD = 3
 _HEARTBEAT_AUTO_STARVATION_LOOKBACK_LIMIT = 32
+_HEARTBEAT_MODES = {"normal", "full_speed"}
+_HEARTBEAT_PENDING_RESCUE_AGE_SECONDS = 20 * 60
+_HEARTBEAT_PENDING_RESCUE_SKIP_THRESHOLD = 3
+_HEARTBEAT_PENDING_RESCUE_MIN_DELAY_SECONDS = 5
+_FULL_SPEED_HEARTBEAT_DELAY_SECONDS = 5
+_FULL_SPEED_STOP_HOOK_STATUS_MESSAGE = "agent-manager full-speed heartbeat hook"
+_FULL_SPEED_STOP_HOOK_SKIP_TTL_SECONDS = 180
 
 
 def _normalize_heartbeat_session_mode(value: object) -> str:
@@ -1115,8 +1122,44 @@ def _has_pending_heartbeat(pane_output: str, stale_threshold_seconds: int = 900)
     return False, ''
 
 
+def _generate_heartbeat_id(now: Optional[datetime] = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+    return current.strftime('%Y%m%d-%H%M%S')
+
+
+def _heartbeat_id_age_seconds(heartbeat_id: object, *, now: Optional[datetime] = None) -> Optional[int]:
+    text = str(heartbeat_id or '').strip()
+    if not text:
+        return None
+    try:
+        hb_time = datetime.strptime(text, '%Y%m%d-%H%M%S').replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+    return max(0, int((current - hb_time).total_seconds()))
+
+
+def _heartbeat_already_acknowledged(repo_root: Path, *, agent_id: str, heartbeat_id: str) -> bool:
+    if not heartbeat_id:
+        return False
+    events = _read_heartbeat_audit_events(repo_root, agent_id=agent_id, heartbeat_id=heartbeat_id, limit=20)
+    for event in events:
+        if str(event.get('send_status', '')) != 'ok':
+            continue
+        if str(event.get('ack_status', '')) in {'ack', 'yielded'}:
+            return True
+    return False
+
+
 def _heartbeat_preflight_runtime_state(
     *,
+    repo_root: Optional[Path] = None,
     agent_id: str,
     launcher: str,
     sample_count: int = _HEARTBEAT_PREFLIGHT_SAMPLE_COUNT,
@@ -1150,7 +1193,8 @@ def _heartbeat_preflight_runtime_state(
     # Check for pending heartbeat in pane before sampling.
     pending, pending_hb_id = _has_pending_heartbeat(previous_output)
     if pending:
-        return 'busy', f'pending_heartbeat:{pending_hb_id}'
+        if repo_root is None or not _heartbeat_already_acknowledged(repo_root, agent_id=agent_id, heartbeat_id=pending_hb_id):
+            return 'busy', f'pending_heartbeat:{pending_hb_id}'
 
     for sample_index in range(1, samples):
         time.sleep(interval)
@@ -1653,6 +1697,7 @@ def _count_consecutive_auto_preflight_skips(
     repo_root: Path,
     *,
     agent_id: str,
+    reason_codes: Optional[set[str]] = None,
     limit: int = _HEARTBEAT_AUTO_STARVATION_LOOKBACK_LIMIT,
 ) -> int:
     events = _read_heartbeat_audit_events(
@@ -1664,8 +1709,18 @@ def _count_consecutive_auto_preflight_skips(
     for event in events:
         if not _is_auto_preflight_skip_event(event):
             break
+        if reason_codes is not None and str(event.get('reason_code', '')) not in reason_codes:
+            break
         count += 1
     return count
+
+
+def _parse_pending_heartbeat_reason(reason: object) -> str:
+    text = str(reason or '').strip()
+    prefix = 'pending_heartbeat:'
+    if not text.startswith(prefix):
+        return ''
+    return text[len(prefix):].strip()
 
 
 def cmd_heartbeat_trace(args) -> int:
@@ -1834,6 +1889,47 @@ def _notify_heartbeat_failure(
         heartbeat_id=heartbeat_id,
         failure_type=failure_type,
     )
+
+
+def _schedule_pending_heartbeat_rescue_timer(
+    *,
+    agent_file_id: str,
+    pending_heartbeat_id: str,
+    delay_seconds: int,
+    timeout_seconds: Optional[int],
+) -> bool:
+    delay = max(_HEARTBEAT_PENDING_RESCUE_MIN_DELAY_SECONDS, int(delay_seconds or 0))
+    dedupe_key = f"pending-rescue:{str(agent_file_id or '').strip().lower()}:{pending_heartbeat_id}"
+    args = argparse.Namespace(
+        timer_command='rescue',
+        agent=agent_file_id,
+        delay=f'{delay}s',
+        timeout=f'{int(timeout_seconds)}s' if timeout_seconds else None,
+        reason='auto_pending_heartbeat_rescue',
+        no_prime=False,
+        fresh=False,
+        heartbeat_id=pending_heartbeat_id,
+        dedupe_key=dedupe_key,
+    )
+    return cmd_timer(args) == 0
+
+
+def _restart_heartbeat_session_restore(agent_file_id: str, agent_name: str, agent_id: str) -> bool:
+    print(f"♻️  Restarting '{agent_name}' in restore mode")
+    if session_exists(agent_id):
+        stop_session(agent_id)
+        time.sleep(1)
+
+    restart_args = argparse.Namespace(
+        agent=agent_file_id,
+        working_dir=None,
+        restore=True,
+        tmux_layout='sessions',
+    )
+    if cmd_start(restart_args) != 0:
+        print(f"❌ Failed to restart '{agent_name}' in restore mode")
+        return False
+    return True
 
 
 def _restart_heartbeat_session_fresh(agent_file_id: str, agent_name: str, agent_id: str) -> bool:
@@ -2224,6 +2320,7 @@ def cmd_dream_run(args):
 
     launcher = resolve_launcher_command(agent_config.get('launcher', ''))
     preflight_state, preflight_reason = _heartbeat_preflight_runtime_state(
+        repo_root=repo_root,
         agent_id=agent_id,
         launcher=launcher,
     )
@@ -2436,7 +2533,7 @@ def cmd_heartbeat_run(args):
     )
 
     # Standard heartbeat message (with traceable id for delivery debugging)
-    heartbeat_id = time.strftime('%Y%m%d-%H%M%S')
+    heartbeat_id = _generate_heartbeat_id()
     print(f"   HB_ID: {heartbeat_id}")
     recovery_action = ''
 
@@ -2502,6 +2599,7 @@ def cmd_heartbeat_run(args):
 
     if session_mode == 'auto':
         preflight_state, preflight_reason = _heartbeat_preflight_runtime_state(
+            repo_root=repo_root,
             agent_id=agent_id,
             launcher=launcher,
         )

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -726,6 +726,219 @@ def _normalize_heartbeat_session_mode(value: object) -> str:
     return "restore"
 
 
+def _normalize_heartbeat_mode(value: object) -> str:
+    mode = str(value or "normal").strip().lower()
+    if mode in _HEARTBEAT_MODES:
+        return mode
+    return "normal"
+
+
+def _resolve_auto_starvation_skip_threshold(heartbeat: object) -> Optional[int]:
+    if not isinstance(heartbeat, dict):
+        return _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD
+
+    raw_value = heartbeat.get('auto_starvation_skip_threshold')
+    if raw_value is None:
+        recovery = heartbeat.get('recovery')
+        if isinstance(recovery, dict):
+            raw_value = recovery.get('auto_starvation_skip_threshold')
+
+    if raw_value is None:
+        return _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD
+
+    try:
+        threshold = int(raw_value)
+    except Exception:
+        return _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD
+
+    if threshold <= 0:
+        return None
+    return threshold
+
+
+def _resolve_codex_config_dir(working_dir: str) -> Path:
+    current = Path(working_dir).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / '.git').exists():
+            return candidate / '.codex'
+    return current / '.codex'
+
+
+def _heartbeat_stop_hook_skip_file(repo_root: Path, agent_id: str) -> Path:
+    safe_agent_id = str(agent_id or 'unknown').strip().lower().replace('_', '-')
+    safe_agent_id = re.sub(r'[^a-z0-9_-]+', '-', safe_agent_id)
+    return (
+        repo_root
+        / '.claude'
+        / 'state'
+        / 'agent-manager'
+        / 'stop-hook-skips'
+        / f'{safe_agent_id}.json'
+    )
+
+
+def arm_codex_fullspeed_stop_hook_skip(
+    agent_ref: object,
+    *,
+    reason: str,
+    ttl_seconds: int = _FULL_SPEED_STOP_HOOK_SKIP_TTL_SECONDS,
+) -> bool:
+    agent_config = agent_ref if isinstance(agent_ref, dict) else resolve_agent(str(agent_ref or ''))
+    if not isinstance(agent_config, dict):
+        return False
+
+    heartbeat = agent_config.get('heartbeat')
+    if not isinstance(heartbeat, dict):
+        return False
+    if _normalize_heartbeat_mode(heartbeat.get('mode')) != 'full_speed':
+        return False
+
+    launcher = resolve_launcher_command(agent_config.get('launcher', ''))
+    if get_provider_key(launcher) != 'codex':
+        return False
+
+    agent_id = get_agent_id(agent_config)
+    repo_root = get_repo_root()
+    skip_file = _heartbeat_stop_hook_skip_file(repo_root, agent_id)
+    skip_file.parent.mkdir(parents=True, exist_ok=True)
+    expires_at = time.time() + max(1, int(ttl_seconds))
+    payload = {
+        'agent_id': agent_id,
+        'reason': str(reason or ''),
+        'expires_at': int(expires_at),
+        'created_at': int(time.time()),
+    }
+    skip_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding='utf-8')
+    return True
+
+
+def _build_fullspeed_stop_hook_command(
+    *,
+    repo_root: Path,
+    agent_file_id: str,
+    agent_id: str,
+    delay_seconds: int,
+) -> str:
+    hook_script = Path(__file__).resolve().parent / 'fullspeed_stop_hook.py'
+    parts = [
+        shlex.quote(sys.executable),
+        shlex.quote(str(hook_script)),
+        '--agent',
+        shlex.quote(str(agent_file_id)),
+        '--agent-id',
+        shlex.quote(str(agent_id)),
+        '--repo-root',
+        shlex.quote(str(repo_root)),
+        '--delay',
+        shlex.quote(str(max(0, int(delay_seconds)))),
+    ]
+    return " ".join(parts)
+
+
+def _is_managed_fullspeed_stop_hook(hook: dict[str, Any]) -> bool:
+    if str(hook.get('type') or '').strip() != 'command':
+        return False
+    if str(hook.get('statusMessage') or '').strip() == _FULL_SPEED_STOP_HOOK_STATUS_MESSAGE:
+        return True
+    command = str(hook.get('command') or '').strip()
+    return 'fullspeed_stop_hook.py' in command
+
+
+def _sync_codex_fullspeed_stop_hook(
+    agent_config: dict,
+    *,
+    working_dir: str,
+    repo_root: Optional[Path] = None,
+    delay_seconds: int = _FULL_SPEED_HEARTBEAT_DELAY_SECONDS,
+) -> dict[str, object]:
+    heartbeat = agent_config.get('heartbeat')
+    if not isinstance(heartbeat, dict):
+        return {'enabled': False, 'reason': 'no_heartbeat'}
+
+    heartbeat_mode = _normalize_heartbeat_mode(heartbeat.get('mode'))
+    launcher = resolve_launcher_command(agent_config.get('launcher', ''))
+    if get_provider_key(launcher) != 'codex':
+        if heartbeat_mode == 'full_speed':
+            return {'enabled': False, 'reason': 'unsupported_provider', 'mode': heartbeat_mode}
+        return {'enabled': False, 'reason': 'not_codex', 'mode': heartbeat_mode}
+
+    config_dir = _resolve_codex_config_dir(working_dir)
+    hooks_path = config_dir / 'hooks.json'
+    config_toml_path = config_dir / 'config.toml'
+    data: dict[str, Any] = {}
+    if hooks_path.exists():
+        try:
+            loaded = json.loads(hooks_path.read_text(encoding='utf-8'))
+        except Exception as exc:
+            raise ValueError(f"Invalid Codex hooks file: {hooks_path} ({exc})") from exc
+        if not isinstance(loaded, dict):
+            raise ValueError(f"Invalid Codex hooks file: {hooks_path} (expected top-level object)")
+        data = dict(loaded)
+
+    hooks_section = data.setdefault('hooks', {})
+    if not isinstance(hooks_section, dict):
+        raise ValueError(f"Invalid Codex hooks file: {hooks_path} (expected 'hooks' object)")
+
+    stop_groups_raw = hooks_section.get('Stop', [])
+    if stop_groups_raw is None:
+        stop_groups_raw = []
+    if not isinstance(stop_groups_raw, list):
+        raise ValueError(f"Invalid Codex hooks file: {hooks_path} (expected 'hooks.Stop' array)")
+
+    stop_groups: list[dict[str, Any]] = []
+    for group in stop_groups_raw:
+        if not isinstance(group, dict):
+            raise ValueError(f"Invalid Codex hooks file: {hooks_path} (expected Stop hook group object)")
+        group_hooks = group.get('hooks', [])
+        if not isinstance(group_hooks, list):
+            raise ValueError(f"Invalid Codex hooks file: {hooks_path} (expected Stop group 'hooks' array)")
+        filtered_hooks = []
+        for hook in group_hooks:
+            if not isinstance(hook, dict):
+                raise ValueError(f"Invalid Codex hooks file: {hooks_path} (expected hook object)")
+            is_managed = _is_managed_fullspeed_stop_hook(hook)
+            if not is_managed:
+                filtered_hooks.append(hook)
+        if filtered_hooks:
+            updated_group = dict(group)
+            updated_group['hooks'] = filtered_hooks
+            stop_groups.append(updated_group)
+
+    updated = False
+    previous_stop_groups = hooks_section.get('Stop')
+    if stop_groups:
+        hooks_section['Stop'] = stop_groups
+    else:
+        hooks_section.pop('Stop', None)
+
+    if hooks_section:
+        data['hooks'] = hooks_section
+    else:
+        data.pop('hooks', None)
+    if previous_stop_groups != hooks_section.get('Stop', None):
+        updated = True
+
+    if data:
+        config_dir.mkdir(parents=True, exist_ok=True)
+        serialized = json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+        current_text = hooks_path.read_text(encoding='utf-8') if hooks_path.exists() else None
+        if current_text != serialized:
+            hooks_path.write_text(serialized, encoding='utf-8')
+            updated = True
+    elif hooks_path.exists():
+        hooks_path.unlink()
+        updated = True
+
+    return {
+        'enabled': True,
+        'active': False,
+        'reason': 'cleaned',
+        'mode': heartbeat_mode,
+        'updated': updated,
+        'hooks_path': str(hooks_path),
+    }
+
+
 def _get_compiled_context_left_patterns(launcher: str) -> list[re.Pattern]:
     provider_key = get_provider_key(launcher)
     cached = _CONTEXT_LEFT_PATTERN_CACHE.get(provider_key)
@@ -2213,6 +2426,7 @@ def cmd_heartbeat_run(args):
     print(f"   Session mode: {session_mode}")
 
     recovery_policy = _parse_heartbeat_recovery_policy(heartbeat, args)
+    auto_starvation_skip_threshold = _resolve_auto_starvation_skip_threshold(heartbeat)
     print(
         "   Recovery policy: "
         f"retry={recovery_policy['max_retries']} "
@@ -2351,19 +2565,22 @@ def cmd_heartbeat_run(args):
                 starvation_guard_armed = skip_reason_code != 'HB_AUTO_PENDING_SKIP'
                 consecutive_skip_count = 0
                 if starvation_guard_armed:
-                    consecutive_skip_count = _count_consecutive_auto_preflight_skips(
-                        repo_root,
-                        agent_id=agent_id,
-                    )
-                    if consecutive_skip_count >= _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD:
-                        recovery_action = 'auto_starvation_bypass'
-                        print(
-                            "⚠️  Auto-mode starvation guard triggered after "
-                            f"{consecutive_skip_count} consecutive preflight skips; "
-                            "dispatching one heartbeat attempt anyway"
-                        )
-                    else:
+                    if auto_starvation_skip_threshold is None:
                         starvation_guard_armed = False
+                    else:
+                        consecutive_skip_count = _count_consecutive_auto_preflight_skips(
+                            repo_root,
+                            agent_id=agent_id,
+                        )
+                        if consecutive_skip_count >= auto_starvation_skip_threshold:
+                            recovery_action = 'auto_starvation_bypass'
+                            print(
+                                "⚠️  Auto-mode starvation guard triggered after "
+                                f"{consecutive_skip_count} consecutive preflight skips; "
+                                "dispatching one heartbeat attempt anyway"
+                            )
+                        else:
+                            starvation_guard_armed = False
                 if not starvation_guard_armed:
                     print(
                         "⏭️  Agent is not idle "

--- a/agent-manager/scripts/runtime_state.py
+++ b/agent-manager/scripts/runtime_state.py
@@ -34,6 +34,24 @@ def detect_first_pattern(output: str, patterns: Sequence[str]) -> Optional[str]:
     return None
 
 
+def _tail_text(output: str, *, max_lines: int) -> str:
+    lines = str(output or '').splitlines()
+    if len(lines) <= max_lines:
+        return str(output or '')
+    return "\n".join(lines[-max_lines:])
+
+
+def _detect_codex_conversation_interrupted(output: str) -> bool:
+    """True only when Codex's UI interrupted marker is visible.
+
+    We intentionally do NOT treat the plain substring "Conversation interrupted" as
+    a runtime state, because it can appear in user-provided text (e.g. Slack
+    messages, quoted logs, runbooks) and would cause false positives.
+    """
+    # Codex renders a square marker at the start of the line.
+    return bool(re.search(r'(?m)^\s*■\s*Conversation interrupted\b', str(output or '')))
+
+
 def parse_elapsed_seconds(output: str) -> Optional[int]:
     """Best-effort parse of an on-screen elapsed timer (e.g., "[⏱ 5m 7s]")."""
     if not output:
@@ -169,11 +187,15 @@ def evaluate_runtime_state(
     # Detect interrupted turn (Codex suggestion tip appeared mid-turn).
     interrupted_patterns = list(cfg.get('interrupted_patterns', []) or [])
     suggestion_tip_re = cfg.get('suggestion_tip_pattern')
+    # Only classify as interrupted when Codex's UI marker is present in recent output.
+    # Do not let arbitrary quoted text (e.g. Slack messages) trigger it.
     interrupted_match = detect_first_pattern(output, interrupted_patterns)
     if interrupted_match:
-        payload['state'] = 'interrupted'
-        payload['reason'] = f'interrupted:{interrupted_match}'
-        return payload
+        tail = _tail_text(output, max_lines=20)
+        if _detect_codex_conversation_interrupted(tail):
+            payload['state'] = 'interrupted'
+            payload['reason'] = f'interrupted:{interrupted_match}'
+            return payload
 
     # Suggestion tip visible on last line(s) while no busy pattern → interrupted.
     if suggestion_tip_re:

--- a/agent-manager/scripts/schedule_helper.py
+++ b/agent-manager/scripts/schedule_helper.py
@@ -349,10 +349,13 @@ def list_heartbeats_formatted() -> str:
         cron = hb.get('cron', 'N/A')
         max_runtime = hb.get('max_runtime', '')
         session_mode = str(hb.get('session_mode', 'restore') or 'restore').strip().lower()
+        heartbeat_mode = str(hb.get('mode', 'normal') or 'normal').strip().lower()
         details = []
         if max_runtime:
             details.append(max_runtime)
-        details.append(f"mode:{session_mode}")
+        details.append(f"session:{session_mode}")
+        if heartbeat_mode != 'normal':
+            details.append(f"heartbeat:{heartbeat_mode}")
 
         schedule = hb.get('schedule')
         if schedule:

--- a/agent-manager/scripts/tests/test_cli_modular_slice1.py
+++ b/agent-manager/scripts/tests/test_cli_modular_slice1.py
@@ -52,6 +52,16 @@ class CliModularSlice1Tests(unittest.TestCase):
         self.assertEqual(args.window, 'daily')
         self.assertIsNone(args.agent)
 
+    def test_heartbeat_rescue_flags(self):
+        args = create_parser().parse_args(['heartbeat', 'rescue', 'main', '--timeout', '8m', '--reason', 'stale pending'])
+        self.assertEqual(args.command, 'heartbeat')
+        self.assertEqual(args.heartbeat_command, 'rescue')
+        self.assertEqual(args.agent, 'main')
+        self.assertEqual(args.timeout, '8m')
+        self.assertEqual(args.reason, 'stale pending')
+        self.assertFalse(args.no_prime)
+        self.assertFalse(args.fresh)
+
     def test_inbound_drain_once_flags(self):
         args = create_parser().parse_args(['inbound', 'drain', 'main', '--once'])
         self.assertEqual(args.command, 'inbound')
@@ -72,6 +82,15 @@ class CliModularSlice1Tests(unittest.TestCase):
         self.assertEqual(args.agent, 'main')
         self.assertEqual(args.delay, '5s')
         self.assertEqual(args.timeout, '8m')
+
+    def test_timer_rescue_flags(self):
+        args = create_parser().parse_args(['timer', 'rescue', 'main', '--delay', '5s', '--timeout', '8m', '--reason', 'auto'])
+        self.assertEqual(args.command, 'timer')
+        self.assertEqual(args.timer_command, 'rescue')
+        self.assertEqual(args.agent, 'main')
+        self.assertEqual(args.delay, '5s')
+        self.assertEqual(args.timeout, '8m')
+        self.assertEqual(args.reason, 'auto')
 
     def test_timer_command_remainder_flags(self):
         args = create_parser().parse_args(['timer', 'command', '--delay', '5s', '--', 'heartbeat', 'run', 'main'])
@@ -166,6 +185,7 @@ class CliModularSlice1Tests(unittest.TestCase):
         self.assertEqual(result, 43)
         mock_handler.assert_called_once()
         self.assertIs(mock_handler.call_args.kwargs['run_handler'], main.cmd_heartbeat_run)
+        self.assertIs(mock_handler.call_args.kwargs['rescue_handler'], main.cmd_heartbeat_rescue)
         self.assertIs(mock_handler.call_args.kwargs['trace_handler'], main.cmd_heartbeat_trace)
         self.assertIs(mock_handler.call_args.kwargs['slo_handler'], main.cmd_heartbeat_slo)
 

--- a/agent-manager/scripts/tests/test_heartbeat_command.py
+++ b/agent-manager/scripts/tests/test_heartbeat_command.py
@@ -28,6 +28,7 @@ class HeartbeatCommandTests(unittest.TestCase):
             code, text = self._run(
                 args,
                 run_handler=lambda _args: 99,
+                rescue_handler=lambda _args: 98,
                 trace_handler=lambda _args: 99,
                 slo_handler=lambda _args: 99,
             )
@@ -41,6 +42,7 @@ class HeartbeatCommandTests(unittest.TestCase):
             code, text = self._run(
                 args,
                 run_handler=lambda _args: 99,
+                rescue_handler=lambda _args: 98,
                 trace_handler=lambda _args: 99,
                 slo_handler=lambda _args: 99,
             )
@@ -58,6 +60,7 @@ class HeartbeatCommandTests(unittest.TestCase):
             code, text = self._run(
                 args,
                 run_handler=lambda _args: 99,
+                rescue_handler=lambda _args: 98,
                 trace_handler=lambda _args: 99,
                 slo_handler=lambda _args: 99,
             )
@@ -68,29 +71,41 @@ class HeartbeatCommandTests(unittest.TestCase):
 
     def test_run_trace_and_slo_delegate_handlers(self):
         run_args = argparse.Namespace(heartbeat_command='run')
+        rescue_args = argparse.Namespace(heartbeat_command='rescue')
         trace_args = argparse.Namespace(heartbeat_command='trace')
         slo_args = argparse.Namespace(heartbeat_command='slo')
 
         code_run, _ = self._run(
             run_args,
             run_handler=lambda _args: 11,
+            rescue_handler=lambda _args: 44,
+            trace_handler=lambda _args: 22,
+            slo_handler=lambda _args: 33,
+        )
+        code_rescue, _ = self._run(
+            rescue_args,
+            run_handler=lambda _args: 11,
+            rescue_handler=lambda _args: 44,
             trace_handler=lambda _args: 22,
             slo_handler=lambda _args: 33,
         )
         code_trace, _ = self._run(
             trace_args,
             run_handler=lambda _args: 11,
+            rescue_handler=lambda _args: 44,
             trace_handler=lambda _args: 22,
             slo_handler=lambda _args: 33,
         )
         code_slo, _ = self._run(
             slo_args,
             run_handler=lambda _args: 11,
+            rescue_handler=lambda _args: 44,
             trace_handler=lambda _args: 22,
             slo_handler=lambda _args: 33,
         )
 
         self.assertEqual(code_run, 11)
+        self.assertEqual(code_rescue, 44)
         self.assertEqual(code_trace, 22)
         self.assertEqual(code_slo, 33)
 
@@ -99,6 +114,7 @@ class HeartbeatCommandTests(unittest.TestCase):
         code, text = self._run(
             args,
             run_handler=lambda _args: 11,
+            rescue_handler=lambda _args: 44,
             trace_handler=lambda _args: 22,
             slo_handler=lambda _args: 33,
         )

--- a/agent-manager/scripts/tests/test_heartbeat_recovery.py
+++ b/agent-manager/scripts/tests/test_heartbeat_recovery.py
@@ -70,6 +70,23 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         self.assertFalse(main._should_retry_heartbeat_attempt(failure_type='unknown', attempt_index=0, max_retries=1))
         self.assertFalse(main._should_retry_heartbeat_attempt(failure_type='send_fail', attempt_index=1, max_retries=1))
 
+    def test_resolve_auto_starvation_skip_threshold_defaults_and_disable(self):
+        self.assertEqual(
+            main._resolve_auto_starvation_skip_threshold({'enabled': True}),
+            main._HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD,
+        )
+        self.assertEqual(
+            main._resolve_auto_starvation_skip_threshold({'auto_starvation_skip_threshold': 5}),
+            5,
+        )
+        self.assertEqual(
+            main._resolve_auto_starvation_skip_threshold({'recovery': {'auto_starvation_skip_threshold': 7}}),
+            7,
+        )
+        self.assertIsNone(
+            main._resolve_auto_starvation_skip_threshold({'auto_starvation_skip_threshold': 0}),
+        )
+
     def test_count_consecutive_auto_preflight_skips_stops_at_first_attempt(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)
@@ -1336,6 +1353,65 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         mock_audit.assert_called_once()
         self.assertEqual(mock_audit.call_args.kwargs.get('phase'), 'attempt')
         self.assertEqual(mock_audit.call_args.kwargs.get('recovery_action'), 'auto_starvation_bypass')
+
+    @patch('main._append_heartbeat_audit_event')
+    @patch('main.time.sleep', return_value=None)
+    @patch('main._run_heartbeat_attempt')
+    @patch('main._maybe_rollover_heartbeat_session', return_value=None)
+    @patch('main._count_consecutive_auto_preflight_skips', return_value=99)
+    @patch('main._heartbeat_preflight_runtime_state', return_value=('busy', 'busy_pattern:Thinking...'))
+    @patch('main._detect_agent_context_left_percent', return_value=55)
+    @patch('main.resolve_launcher_command', return_value='codex')
+    @patch('main.session_exists', return_value=True)
+    @patch('main.resolve_agent')
+    @patch('main.check_tmux', return_value=True)
+    def test_cmd_heartbeat_run_auto_mode_can_disable_starvation_bypass(
+        self,
+        _mock_tmux,
+        mock_resolve_agent,
+        _mock_session,
+        _mock_launcher,
+        _mock_context,
+        _mock_preflight,
+        _mock_skip_count,
+        _mock_rollover,
+        mock_run_attempt,
+        _mock_sleep,
+        mock_audit,
+    ):
+        mock_resolve_agent.return_value = {
+            'name': 'main',
+            'file_id': 'main',
+            'enabled': True,
+            'heartbeat': {
+                'enabled': True,
+                'session_mode': 'auto',
+                'auto_starvation_skip_threshold': 0,
+                'recovery': {
+                    'max_retries': 1,
+                    'retry_backoff_seconds': 0,
+                    'fallback_mode': 'none',
+                },
+            },
+            'launcher': 'codex',
+        }
+
+        args = type('Args', (), {
+            'agent': 'main',
+            'timeout': None,
+            'retry': None,
+            'backoff_seconds': 0,
+            'fallback_mode': None,
+            'notify_on_failure': False,
+            'notifier_channel': None,
+        })()
+
+        result = main.cmd_heartbeat_run(args)
+        self.assertEqual(result, 0)
+        mock_run_attempt.assert_not_called()
+        mock_audit.assert_called_once()
+        self.assertEqual(mock_audit.call_args.kwargs.get('phase'), 'preflight')
+        self.assertEqual(mock_audit.call_args.kwargs.get('failure_type'), 'busy_skip')
 
     @patch('main._append_heartbeat_audit_event')
     @patch('main._schedule_pending_heartbeat_rescue_timer', return_value=True)

--- a/agent-manager/scripts/tests/test_heartbeat_recovery.py
+++ b/agent-manager/scripts/tests/test_heartbeat_recovery.py
@@ -162,6 +162,71 @@ class HeartbeatRecoveryTests(unittest.TestCase):
                 2,
             )
 
+    def test_count_consecutive_auto_preflight_skips_can_filter_reason_codes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            main._append_heartbeat_audit_event(
+                repo_root,
+                agent_id='emp-0001',
+                heartbeat_id='hb-pending-2',
+                send_status='skip',
+                ack_status='not_checked',
+                duration_ms=0,
+                context_left=55,
+                failure_type='pending_skip',
+                session_mode='auto',
+                phase='preflight',
+                attempt=0,
+                recovery_action='skip_busy',
+                reason_code='HB_AUTO_PENDING_SKIP',
+                timestamp='2026-03-12T10:03:00Z',
+            )
+            main._append_heartbeat_audit_event(
+                repo_root,
+                agent_id='emp-0001',
+                heartbeat_id='hb-pending-1',
+                send_status='skip',
+                ack_status='not_checked',
+                duration_ms=0,
+                context_left=55,
+                failure_type='pending_skip',
+                session_mode='auto',
+                phase='preflight',
+                attempt=0,
+                recovery_action='skip_busy',
+                reason_code='HB_AUTO_PENDING_SKIP',
+                timestamp='2026-03-12T10:02:00Z',
+            )
+            main._append_heartbeat_audit_event(
+                repo_root,
+                agent_id='emp-0001',
+                heartbeat_id='hb-busy',
+                send_status='skip',
+                ack_status='not_checked',
+                duration_ms=0,
+                context_left=55,
+                failure_type='busy_skip',
+                session_mode='auto',
+                phase='preflight',
+                attempt=0,
+                recovery_action='skip_busy',
+                reason_code='HB_AUTO_BUSY_SKIP',
+                timestamp='2026-03-12T10:01:00Z',
+            )
+
+            self.assertEqual(
+                main._count_consecutive_auto_preflight_skips(
+                    repo_root,
+                    agent_id='emp-0001',
+                    reason_codes={'HB_AUTO_PENDING_SKIP'},
+                ),
+                2,
+            )
+
+    def test_generate_heartbeat_id_uses_utc(self):
+        local_now = datetime(2026, 3, 26, 0, 50, 1, tzinfo=timezone(timedelta(hours=8)))
+        self.assertEqual(main._generate_heartbeat_id(local_now), '20260325-165001')
+
     @patch('main.time.sleep', return_value=None)
     @patch('main.capture_output', side_effect=['pane-a', 'pane-b'])
     @patch('main.get_agent_runtime_state', return_value={'state': 'idle', 'reason': 'ready'})
@@ -197,6 +262,46 @@ class HeartbeatRecoveryTests(unittest.TestCase):
             sample_interval_seconds=0.1,
             capture_lines=40,
         )
+        self.assertEqual(state, 'idle')
+        self.assertEqual(reason, 'ready')
+
+    @patch('main.time.sleep', return_value=None)
+    @patch('main.capture_output', side_effect=[
+        'Read HEARTBEAT.md... [HB_ID:20260321-004002]\n• 已处理并继续执行\n',
+        'Read HEARTBEAT.md... [HB_ID:20260321-004002]\n• 已处理并继续执行\n',
+    ])
+    @patch('main.get_agent_runtime_state', return_value={'state': 'idle', 'reason': 'ready'})
+    def test_heartbeat_preflight_ignores_acknowledged_pending_marker(
+        self,
+        _mock_runtime,
+        _mock_capture,
+        _mock_sleep,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            main._append_heartbeat_audit_event(
+                repo_root,
+                agent_id='emp-0001',
+                heartbeat_id='20260321-004002',
+                send_status='ok',
+                ack_status='ack',
+                duration_ms=4661,
+                context_left=35,
+                session_mode='auto',
+                phase='attempt',
+                attempt=1,
+                timestamp='2026-03-20T16:40:10Z',
+            )
+
+            state, reason = main._heartbeat_preflight_runtime_state(
+                repo_root=repo_root,
+                agent_id='emp-0001',
+                launcher='codex',
+                sample_count=2,
+                sample_interval_seconds=0.1,
+                capture_lines=40,
+            )
+
         self.assertEqual(state, 'idle')
         self.assertEqual(reason, 'ready')
 
@@ -399,12 +504,14 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         self.assertEqual(mock_send.call_count, 2)
         mock_recover.assert_called_once()
 
+    @patch('main.arm_codex_fullspeed_stop_hook_skip')
     @patch('main.cmd_start', return_value=0)
     @patch('main.stop_session', return_value=True)
     @patch('main.time.sleep', return_value=None)
-    def test_restart_heartbeat_session_fresh(self, _mock_sleep, _mock_stop, _mock_start):
+    def test_restart_heartbeat_session_fresh(self, _mock_sleep, _mock_stop, _mock_start, mock_arm_skip):
         ok = main._restart_heartbeat_session_fresh('EMP_0001', 'qa-agent', 'emp-0001')
         self.assertTrue(ok)
+        mock_arm_skip.assert_not_called()
 
     @patch('main._notify_heartbeat_failure', return_value=True)
     @patch('main._append_heartbeat_audit_event')
@@ -1231,10 +1338,12 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         self.assertEqual(mock_audit.call_args.kwargs.get('recovery_action'), 'auto_starvation_bypass')
 
     @patch('main._append_heartbeat_audit_event')
+    @patch('main._schedule_pending_heartbeat_rescue_timer', return_value=True)
+    @patch('main._heartbeat_id_age_seconds', return_value=60)
     @patch('main.time.sleep', return_value=None)
     @patch('main._run_heartbeat_attempt')
     @patch('main._maybe_rollover_heartbeat_session', return_value=None)
-    @patch('main._count_consecutive_auto_preflight_skips', return_value=main._HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD + 2)
+    @patch('main._count_consecutive_auto_preflight_skips', return_value=1)
     @patch('main._heartbeat_preflight_runtime_state', return_value=('busy', 'pending_heartbeat:20260317-010101'))
     @patch('main._detect_agent_context_left_percent', return_value=55)
     @patch('main.resolve_launcher_command', return_value='codex')
@@ -1253,6 +1362,8 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         _mock_rollover,
         mock_run_attempt,
         _mock_sleep,
+        _mock_hb_age,
+        mock_schedule_rescue,
         mock_audit,
     ):
         mock_resolve_agent.return_value = {
@@ -1284,10 +1395,84 @@ class HeartbeatRecoveryTests(unittest.TestCase):
         result = main.cmd_heartbeat_run(args)
         self.assertEqual(result, 0)
         mock_run_attempt.assert_not_called()
+        mock_schedule_rescue.assert_called_once()
         mock_audit.assert_called_once()
         self.assertEqual(mock_audit.call_args.kwargs.get('phase'), 'preflight')
         self.assertEqual(mock_audit.call_args.kwargs.get('failure_type'), 'pending_skip')
         self.assertEqual(mock_audit.call_args.kwargs.get('reason_code'), 'HB_AUTO_PENDING_SKIP')
+        self.assertEqual(mock_audit.call_args.kwargs.get('recovery_action'), 'schedule_pending_rescue_timer')
+
+    @patch('main._append_heartbeat_audit_event')
+    @patch('main._schedule_pending_heartbeat_rescue_timer')
+    @patch('main._restart_heartbeat_session_restore', return_value=True)
+    @patch('main.time.sleep', return_value=None)
+    @patch('main._run_heartbeat_attempt', return_value={
+        'send_status': 'ok',
+        'ack_status': 'ack',
+        'failure_type': '',
+        'reason_code': '',
+        'duration_ms': 1,
+    })
+    @patch('main._maybe_rollover_heartbeat_session', return_value=None)
+    @patch('main._count_consecutive_auto_preflight_skips', side_effect=[main._HEARTBEAT_PENDING_RESCUE_SKIP_THRESHOLD, 0])
+    @patch('main._heartbeat_id_age_seconds', return_value=main._HEARTBEAT_PENDING_RESCUE_AGE_SECONDS + 5)
+    @patch('main._heartbeat_preflight_runtime_state', return_value=('busy', 'pending_heartbeat:20260317-010101'))
+    @patch('main._detect_agent_context_left_percent', return_value=55)
+    @patch('main.resolve_launcher_command', return_value='codex')
+    @patch('main.session_exists', return_value=True)
+    @patch('main.resolve_agent')
+    @patch('main.check_tmux', return_value=True)
+    def test_cmd_heartbeat_run_auto_mode_rescues_stale_pending_heartbeat(
+        self,
+        _mock_tmux,
+        mock_resolve_agent,
+        _mock_session,
+        _mock_launcher,
+        _mock_context,
+        _mock_preflight,
+        _mock_hb_age,
+        _mock_skip_count,
+        _mock_rollover,
+        mock_run_attempt,
+        _mock_sleep,
+        mock_restart_restore,
+        mock_schedule_rescue,
+        mock_audit,
+    ):
+        mock_resolve_agent.return_value = {
+            'name': 'qa-agent',
+            'file_id': 'EMP_0001',
+            'enabled': True,
+            'heartbeat': {
+                'enabled': True,
+                'session_mode': 'auto',
+                'recovery': {
+                    'max_retries': 1,
+                    'retry_backoff_seconds': 0,
+                    'fallback_mode': 'none',
+                },
+            },
+            'launcher': 'codex',
+        }
+
+        args = type('Args', (), {
+            'agent': 'EMP_0001',
+            'timeout': None,
+            'retry': None,
+            'backoff_seconds': 0,
+            'fallback_mode': None,
+            'notify_on_failure': False,
+            'notifier_channel': None,
+        })()
+
+        result = main.cmd_heartbeat_run(args)
+        self.assertEqual(result, 0)
+        mock_restart_restore.assert_called_once()
+        mock_schedule_rescue.assert_not_called()
+        mock_run_attempt.assert_called_once()
+        self.assertGreaterEqual(mock_audit.call_count, 1)
+        self.assertEqual(mock_audit.call_args.kwargs.get('phase'), 'attempt')
+        self.assertEqual(mock_audit.call_args.kwargs.get('recovery_action'), 'auto_pending_rescue')
 
     @patch('main._append_heartbeat_audit_event')
     @patch('main.time.sleep', return_value=None)
@@ -1384,6 +1569,32 @@ class RuntimeStateInterruptedTests(unittest.TestCase):
         )
         self.assertEqual(result['state'], 'interrupted')
         self.assertIn('interrupted', result.get('reason', ''))
+
+    def test_plain_text_conversation_interrupted_is_not_interrupted(self):
+        """Quoted/plain text mentioning 'Conversation interrupted' should not trigger interrupted."""
+        output = (
+            "• Reading Slack transcript\n"
+            "用户说：这里应该是 Conversation interrupted 的误判，不是 Codex UI 中断。\n"
+            "继续检查 timer 和 heartbeat 逻辑。\n"
+        )
+        result = self.runtime_state.evaluate_runtime_state(
+            output=output,
+            runtime_config=self.codex_runtime_cfg,
+        )
+        self.assertNotEqual(result['state'], 'interrupted')
+        self.assertEqual(result['state'], 'idle')
+
+    def test_old_plain_text_interrupted_plus_busy_marker_stays_busy(self):
+        """Busy pane with quoted text should remain busy, not interrupted."""
+        output = (
+            "Slack transcript: Conversation interrupted was reported by the user.\n"
+            "• Working (4s • esc to interrupt)\n"
+        )
+        result = self.runtime_state.evaluate_runtime_state(
+            output=output,
+            runtime_config=self.codex_runtime_cfg,
+        )
+        self.assertEqual(result['state'], 'busy')
 
     def test_suggestion_tip_with_shortcuts_detected(self):
         """Suggestion tip '› Write tests...' + '? for shortcuts' → interrupted."""

--- a/agent-manager/scripts/tests/test_heartbeat_session_mode.py
+++ b/agent-manager/scripts/tests/test_heartbeat_session_mode.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parents[1]
@@ -14,6 +15,12 @@ import main  # noqa: E402
 
 
 class HeartbeatSessionModeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_root = Path(tempfile.mkdtemp(prefix='heartbeat-mode-'))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_root, ignore_errors=True)
+
     def test_normalize_heartbeat_session_mode(self):
         self.assertEqual(main._normalize_heartbeat_session_mode('auto'), 'auto')
         self.assertEqual(main._normalize_heartbeat_session_mode('fresh'), 'fresh')
@@ -22,6 +29,13 @@ class HeartbeatSessionModeTests(unittest.TestCase):
         self.assertEqual(main._normalize_heartbeat_session_mode('AUTO'), 'auto')
         self.assertEqual(main._normalize_heartbeat_session_mode('unknown'), 'restore')
         self.assertEqual(main._normalize_heartbeat_session_mode(None), 'restore')
+
+    def test_normalize_heartbeat_mode(self):
+        self.assertEqual(main._normalize_heartbeat_mode('full_speed'), 'full_speed')
+        self.assertEqual(main._normalize_heartbeat_mode('FULL_SPEED'), 'full_speed')
+        self.assertEqual(main._normalize_heartbeat_mode('normal'), 'normal')
+        self.assertEqual(main._normalize_heartbeat_mode('unknown'), 'normal')
+        self.assertEqual(main._normalize_heartbeat_mode(None), 'normal')
 
     def test_extract_context_left_percent_prefers_latest_match(self):
         output = (
@@ -61,6 +75,106 @@ class HeartbeatSessionModeTests(unittest.TestCase):
         self.assertFalse(main._should_rollover_heartbeat_session('auto', 25))
         self.assertFalse(main._should_rollover_heartbeat_session('auto', None))
         self.assertFalse(main._should_rollover_heartbeat_session('restore', 1))
+
+    def test_sync_codex_fullspeed_stop_hook_writes_managed_hook(self):
+        workspace = self.temp_root / 'workspace'
+        codex_dir = workspace / '.codex'
+        codex_dir.mkdir(parents=True, exist_ok=True)
+        (workspace / '.git').mkdir()
+        hooks_payload = {
+            'hooks': {
+                'Stop': [
+                    {
+                        'hooks': [
+                            {
+                                'type': 'command',
+                                'command': 'python3 /tmp/fullspeed_stop_hook.py --agent EMP_0001',
+                                'statusMessage': main._FULL_SPEED_STOP_HOOK_STATUS_MESSAGE,
+                            },
+                            {
+                                'type': 'command',
+                                'command': 'python3 /tmp/custom.py',
+                                'statusMessage': 'custom stop hook',
+                            },
+                        ]
+                    }
+                ]
+            }
+        }
+        hooks_path = codex_dir / 'hooks.json'
+        hooks_path.write_text(__import__('json').dumps(hooks_payload, ensure_ascii=False, indent=2) + "\n", encoding='utf-8')
+        agent_config = {
+            'name': 'dev',
+            'file_id': 'EMP_0001',
+            'working_directory': str(workspace),
+            'launcher': 'codex',
+            'heartbeat': {
+                'enabled': True,
+                'mode': 'full_speed',
+                'max_runtime': '5m',
+            },
+        }
+
+        with patch('main.get_repo_root', return_value=self.temp_root):
+            result = main._sync_codex_fullspeed_stop_hook(agent_config, working_dir=str(workspace), repo_root=self.temp_root)
+
+        self.assertTrue(result['enabled'])
+        self.assertTrue(hooks_path.exists())
+        self.assertFalse(result['active'])
+
+        payload = __import__('json').loads(hooks_path.read_text(encoding='utf-8'))
+        stop_groups = payload['hooks']['Stop']
+        self.assertEqual(len(stop_groups), 1)
+        self.assertEqual(stop_groups[0]['hooks'][0]['statusMessage'], 'custom stop hook')
+
+    def test_sync_codex_fullspeed_stop_hook_keeps_managed_hook_when_mode_normal(self):
+        workspace = self.temp_root / 'workspace'
+        codex_dir = workspace / '.codex'
+        codex_dir.mkdir(parents=True, exist_ok=True)
+        (workspace / '.git').mkdir()
+        managed_command = 'python3 /tmp/fullspeed_stop_hook.py --agent EMP_0001'
+        hooks_payload = {
+            'hooks': {
+                'Stop': [
+                    {
+                        'hooks': [
+                            {
+                                'type': 'command',
+                                'command': managed_command,
+                                'statusMessage': main._FULL_SPEED_STOP_HOOK_STATUS_MESSAGE,
+                            },
+                            {
+                                'type': 'command',
+                                'command': 'python3 /tmp/custom.py',
+                                'statusMessage': 'custom stop hook',
+                            },
+                        ]
+                    }
+                ]
+            }
+        }
+        hooks_path = codex_dir / 'hooks.json'
+        hooks_path.write_text(__import__('json').dumps(hooks_payload, ensure_ascii=False, indent=2) + "\n", encoding='utf-8')
+        agent_config = {
+            'name': 'dev',
+            'file_id': 'EMP_0001',
+            'working_directory': str(workspace),
+            'launcher': 'codex',
+            'heartbeat': {
+                'enabled': True,
+                'mode': 'normal',
+            },
+        }
+
+        with patch('main.get_repo_root', return_value=self.temp_root):
+            result = main._sync_codex_fullspeed_stop_hook(agent_config, working_dir=str(workspace), repo_root=self.temp_root)
+
+        self.assertTrue(result['enabled'])
+        self.assertFalse(result['active'])
+        payload = __import__('json').loads(hooks_path.read_text(encoding='utf-8'))
+        stop_groups = payload['hooks']['Stop']
+        self.assertEqual(len(stop_groups), 1)
+        self.assertEqual(stop_groups[0]['hooks'][0]['statusMessage'], 'custom stop hook')
 
 
 if __name__ == '__main__':

--- a/agent-manager/scripts/tests/test_integration_cli_flow.py
+++ b/agent-manager/scripts/tests/test_integration_cli_flow.py
@@ -177,12 +177,18 @@ class CliIntegrationFlowTests(unittest.TestCase):
 
         with ExitStack() as stack:
             self._patch_common(stack, runtime)
+            mock_sync_hook = stack.enter_context(patch(
+                'main._sync_codex_fullspeed_stop_hook',
+                return_value={'enabled': True, 'updated': True, 'reason': 'cleaned', 'hooks_path': '/tmp/hooks.json'},
+            ))
             output = self._run_stage_ok(
                 'start-restore',
                 main.cmd_start,
                 argparse.Namespace(agent='dev', working_dir=None, restore=True, tmux_layout='sessions'),
             )
             self.assertIn('Restored existing session', output, msg='[stage:start-restore] expected restore confirmation')
+            mock_sync_hook.assert_called_once()
+            self.assertIn('Removed deprecated Codex full-speed Stop hook', output, msg='[stage:start-restore] expected hook cleanup notice')
             self.assertEqual(len(runtime.start_commands), 0, msg='[stage:start-restore] should not create a new tmux session')
 
     def test_start_restore_fresh_main_session_runs_inbound_drain_after_ready(self):

--- a/agent-manager/scripts/tests/test_schedule_run_command.py
+++ b/agent-manager/scripts/tests/test_schedule_run_command.py
@@ -167,6 +167,59 @@ class ScheduleRunFlowHelperTests(unittest.TestCase):
         self.assertIn("Run scheduled job 'daily'", task_message)
         self.assertIn(str(task_path), task_message)
 
+    def test_schedule_run_restart_does_not_arm_fullspeed_skip(self):
+        send_calls = []
+        runtime_states = iter([
+            {'state': 'error', 'elapsed_seconds': 0, 'reason': 'timeout'},
+            {'state': 'idle', 'elapsed_seconds': 0, 'reason': ''},
+            {'state': 'busy', 'elapsed_seconds': 1, 'reason': ''},
+            {'state': 'idle', 'elapsed_seconds': 2, 'reason': ''},
+        ])
+        deps = SimpleNamespace(
+            check_tmux=lambda: True,
+            get_agent_schedule=lambda _agent, _job: {
+                '_agent_config': {
+                    'name': 'dev',
+                    'enabled': True,
+                    'file_id': 'EMP_0001',
+                    'launcher': 'codex',
+                },
+                'enabled': True,
+                'max_runtime': '1s',
+                'task': 'run task',
+            },
+            get_agent_id=lambda _cfg: 'emp-0001',
+            get_repo_root=lambda: Path('/tmp'),
+            cleanup_old_logs=lambda _repo_root, days=7: 0,
+            get_schedule_task=lambda _schedule, _repo_root: 'run task',
+            expand_env_vars=lambda value: value,
+            parse_duration=lambda _value: 1,
+            session_exists=lambda _agent_id: True,
+            resolve_launcher_command=lambda _launcher: 'codex',
+            get_agent_runtime_state=lambda _agent_id, launcher='codex': next(runtime_states),
+            stop_session=lambda _agent_id: True,
+            get_provider_key=lambda _launcher: 'codex',
+            send_keys=lambda *args, **kwargs: send_calls.append((args, kwargs)) or True,
+            capture_output=lambda _agent_id, lines=200: 'done',
+            arm_codex_fullspeed_stop_hook_skip=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError('arm_codex_fullspeed_stop_hook_skip should not be called for forced restart')
+            ),
+            _should_use_codex_file_pointer=lambda _task: False,
+            write_scheduled_task_file=lambda *_args: Path('/tmp/generated.md'),
+        )
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            with unittest.mock.patch('commands.schedule_run.time.sleep', return_value=None):
+                code = cmd_schedule_run(
+                    argparse.Namespace(agent='dev', job='daily', timeout='1s'),
+                    deps=deps,
+                    start_handler=lambda _args: 0,
+                )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(len(send_calls), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/agent-manager/scripts/tests/test_start_command.py
+++ b/agent-manager/scripts/tests/test_start_command.py
@@ -46,16 +46,33 @@ class BuildStartCommandTests(unittest.TestCase):
 class LauncherCliConfigTests(unittest.TestCase):
     def test_build_launcher_config_overrides_from_flat_launcher_config(self):
         cfg = {
+            "launcher": "codex",
             "launcher_config": {
                 "model_instructions_file": "prompts/shade.md",
                 "feature_flag": True,
                 "retries": 3,
-            }
+            },
+            "heartbeat": {
+                "enabled": True,
+                "mode": "normal",
+            },
         }
         overrides = main.build_launcher_config_overrides(cfg, working_dir="/repo")
         self.assertEqual(overrides["model_instructions_file"], "/repo/prompts/shade.md")
         self.assertTrue(overrides["feature_flag"])
         self.assertEqual(overrides["retries"], 3)
+
+    def test_build_launcher_config_overrides_does_not_force_codex_hooks(self):
+        cfg = {
+            "launcher": "codex",
+            "launcher_config": {},
+            "heartbeat": {
+                "enabled": False,
+                "mode": "normal",
+            },
+        }
+        overrides = main.build_launcher_config_overrides(cfg, working_dir="/repo")
+        self.assertNotIn("features.codex_hooks", overrides)
 
     def test_to_toml_literal_supports_scalars_lists_and_dicts(self):
         self.assertEqual(main._to_toml_literal("x"), '"x"')

--- a/agent-manager/scripts/tests/test_timer_command.py
+++ b/agent-manager/scripts/tests/test_timer_command.py
@@ -54,6 +54,32 @@ class TimerCommandTests(unittest.TestCase):
         self.assertEqual(payload['timeout'], '8m')
         self.assertEqual(payload['worker_pid'], 12345)
 
+    def test_timer_rescue_schedules_state_and_worker(self):
+        args = argparse.Namespace(
+            timer_command='rescue',
+            agent='main',
+            delay='5s',
+            timeout='8m',
+            reason='stale pending',
+            no_prime=False,
+            fresh=False,
+            heartbeat_id='20260326-010101',
+            dedupe_key='pending-rescue:main:20260326-010101',
+        )
+        with patch('commands.timer._schedule_worker', return_value=12347):
+            code, _text = self._run(args)
+
+        self.assertEqual(code, 0)
+        timer_files = list((self.temp_root / '.claude' / 'state' / 'agent-manager' / 'timers').glob('*.json'))
+        payload = json.loads(timer_files[0].read_text(encoding='utf-8'))
+        self.assertEqual(payload['kind'], 'rescue')
+        self.assertEqual(payload['agent'], 'main')
+        self.assertEqual(payload['timeout'], '8m')
+        self.assertTrue(payload['prime'])
+        self.assertEqual(payload['heartbeat_id'], '20260326-010101')
+        self.assertEqual(payload['dedupe_key'], 'pending-rescue:main:20260326-010101')
+        self.assertEqual(payload['worker_pid'], 12347)
+
     def test_timer_command_requires_command_args(self):
         args = argparse.Namespace(timer_command='command', delay='5s', command_args=['--'])
         code, text = self._run(args)
@@ -70,6 +96,36 @@ class TimerCommandTests(unittest.TestCase):
         payload = json.loads(timer_files[0].read_text(encoding='utf-8'))
         self.assertEqual(payload['kind'], 'command')
         self.assertEqual(payload['command_args'], ['heartbeat', 'run', 'main', '--timeout', '8m'])
+
+    def test_timer_rescue_dedupes_existing_pending_timer(self):
+        timer_dir = self.temp_root / '.claude' / 'state' / 'agent-manager' / 'timers'
+        timer_dir.mkdir(parents=True, exist_ok=True)
+        (timer_dir / 'existing.json').write_text(json.dumps({
+            'timer_id': 'timer-existing',
+            'kind': 'rescue',
+            'status': 'pending',
+            'dedupe_key': 'pending-rescue:main:20260326-010101',
+            'created_at_epoch': 1,
+            'run_at_epoch': 2,
+        }), encoding='utf-8')
+
+        args = argparse.Namespace(
+            timer_command='rescue',
+            agent='main',
+            delay='5s',
+            timeout='8m',
+            reason='stale pending',
+            no_prime=False,
+            fresh=False,
+            heartbeat_id='20260326-010101',
+            dedupe_key='pending-rescue:main:20260326-010101',
+        )
+        with patch('commands.timer._schedule_worker') as worker_mock:
+            code, text = self._run(args)
+
+        self.assertEqual(code, 0)
+        self.assertIn('Timer already scheduled', text)
+        worker_mock.assert_not_called()
 
     def test_timer_list_prints_recent_records(self):
         timer_dir = self.temp_root / '.claude' / 'state' / 'agent-manager' / 'timers'

--- a/agent-manager/scripts/timer_worker.py
+++ b/agent-manager/scripts/timer_worker.py
@@ -67,6 +67,25 @@ def _run_timer(timer_file: Path) -> int:
             [sys.executable, str(main_script), 'start', agent, '--restore'],
             [sys.executable, str(main_script), 'heartbeat', 'run', agent] + (['--timeout', timeout] if timeout else []),
         ]
+    elif kind == 'rescue':
+        agent = str(payload.get('agent') or '').strip()
+        timeout = str(payload.get('timeout') or '').strip()
+        reason = str(payload.get('reason') or '').strip()
+        heartbeat_id = str(payload.get('heartbeat_id') or '').strip()
+        if not agent:
+            _mark(timer_file, status='failed', finished_at=_utc_now_iso(), exit_code=1, error='missing_agent')
+            return 1
+        rescue_reason = " ".join(part for part in [reason, f"hb_id={heartbeat_id}" if heartbeat_id else ''] if part).strip()
+        rescue_cmd = [sys.executable, str(main_script), 'heartbeat', 'rescue', agent]
+        if timeout:
+            rescue_cmd.extend(['--timeout', timeout])
+        if rescue_reason:
+            rescue_cmd.extend(['--reason', rescue_reason])
+        if bool(payload.get('no_prime')) or not bool(payload.get('prime', True)):
+            rescue_cmd.append('--no-prime')
+        if bool(payload.get('fresh')):
+            rescue_cmd.append('--fresh')
+        commands = [rescue_cmd]
     elif kind == 'command':
         command_args = [str(item) for item in list(payload.get('command_args') or []) if str(item)]
         if not command_args:


### PR DESCRIPTION
## Summary
- add `heartbeat rescue` and `timer rescue` flows so supervisor and delayed recovery use one shared rescue path
- fix stale `pending_heartbeat` aging by generating `HB_ID` in UTC and using safer timestamp parsing for TTL checks
- let auto heartbeat recover stale `pending_heartbeat` sessions via restore restart instead of infinitely skipping
- add timer dedupe plus regression coverage for heartbeat rescue, timer rescue, and CLI wiring

## Why
`main` could get stuck in `pending_heartbeat:*` for hours under `session_mode=auto`. When that happened, auto mode kept emitting `HB_AUTO_PENDING_SKIP` and never progressed to recovery. This patch makes stale pending heartbeats expire correctly and promotes them to an explicit rescue path.

## Validation
- `python3 -m py_compile agent-manager/scripts/main.py agent-manager/scripts/cli_parser.py agent-manager/scripts/commands/heartbeat.py agent-manager/scripts/commands/timer.py agent-manager/scripts/timer_worker.py`
- `python3 -m unittest projects/fractalmind-ai/agent-manager-skill/agent-manager/scripts/tests/test_heartbeat_command.py`
- `python3 -m unittest projects/fractalmind-ai/agent-manager-skill/agent-manager/scripts/tests/test_timer_command.py`
- `python3 -m unittest projects/fractalmind-ai/agent-manager-skill/agent-manager/scripts/tests/test_cli_modular_slice1.py`
- `python3 projects/fractalmind-ai/agent-manager-skill/agent-manager/scripts/tests/test_heartbeat_recovery.py HeartbeatRecoveryTests.test_generate_heartbeat_id_uses_utc`
- `python3 projects/fractalmind-ai/agent-manager-skill/agent-manager/scripts/tests/test_heartbeat_recovery.py HeartbeatRecoveryTests.test_cmd_heartbeat_run_auto_mode_does_not_bypass_pending_heartbeat`
- `python3 projects/fractalmind-ai/agent-manager-skill/agent-manager/scripts/tests/test_heartbeat_recovery.py HeartbeatRecoveryTests.test_cmd_heartbeat_run_auto_mode_rescues_stale_pending_heartbeat`
- `python3 projects/fractalmind-ai/agent-manager-skill/agent-manager/scripts/tests/test_heartbeat_recovery.py HeartbeatRecoveryTests.test_count_consecutive_auto_preflight_skips_can_filter_reason_codes`
