### PR TITLE
fix: use stdin when syncing crontab

### DIFF
--- a/agent-manager/scripts/schedule_helper.py
+++ b/agent-manager/scripts/schedule_helper.py
@@ -5,10 +5,8 @@ Manages crontab entries for scheduled agent jobs.
 """
 
 from __future__ import annotations
-import os
 import shlex
 import subprocess
-import tempfile
 from pathlib import Path
 from typing import List, Optional
 
@@ -71,17 +69,12 @@ def get_current_crontab() -> str:
 def set_crontab(content: str) -> bool:
     """Set user's crontab content."""
     try:
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.crontab', delete=False) as f:
-            f.write(content)
-            temp_file = f.name
-
         result = subprocess.run(
-            ['crontab', temp_file],
+            ['crontab', '-'],
+            input=content,
             capture_output=True,
             text=True
         )
-
-        os.unlink(temp_file)
         return result.returncode == 0
     except Exception:
         return False

--- a/agent-manager/scripts/tests/test_schedule_helper.py
+++ b/agent-manager/scripts/tests/test_schedule_helper.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import schedule_helper  # noqa: E402
+
+
+class ScheduleHelperTests(unittest.TestCase):
+    @patch('schedule_helper.subprocess.run')
+    def test_set_crontab_uses_stdin(self, mock_run):
+        mock_run.return_value.returncode = 0
+
+        result = schedule_helper.set_crontab('demo-cron')
+
+        self.assertTrue(result)
+        mock_run.assert_called_once_with(
+            ['crontab', '-'],
+            input='demo-cron',
+            capture_output=True,
+            text=True,
+        )
+
+    @patch('schedule_helper.subprocess.run')
+    def test_set_crontab_returns_false_on_nonzero(self, mock_run):
+        mock_run.return_value.returncode = 1
+
+        result = schedule_helper.set_crontab('demo-cron')
+
+        self.assertFalse(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- switch `schedule_helper.set_crontab()` back to `crontab -` stdin mode
- add a regression test to lock the stdin invocation shape

## Why
On this macOS setup, the temp-file path (`crontab <tempfile>`) is less compatible than stdin mode for agent-manager schedule/heartbeat sync. The local production skill had already been patched to stdin mode, and this PR shares that compatibility fix upstream before we upgrade the local skill to the latest code.

## Validation
- `cd agent-manager/scripts && python3 -m unittest tests.test_schedule_helper tests.test_heartbeat_command tests.test_cli_modular_slice1`
