### PR TITLE
feat: add configurable dream mode

### DIFF
--- a/agent-manager/scripts/cli_parser.py
+++ b/agent-manager/scripts/cli_parser.py
@@ -169,6 +169,15 @@ Examples:
     heartbeat_slo_parser.add_argument('--until', help='Override end time (ISO-8601, UTC recommended)')
     heartbeat_slo_parser.add_argument('--json', action='store_true', help='Output summary as JSON')
 
+    dream_parser = subparsers.add_parser('dream', help='Run dream mode tasks')
+    dream_subparsers = dream_parser.add_subparsers(dest='dream_command', help='Dream commands')
+
+    dream_run_parser = dream_subparsers.add_parser('run', help='Run one dream task manually')
+    dream_run_parser.add_argument('agent', help='Agent name or file ID')
+    dream_run_parser.add_argument('--window-id', help='Expected active dream window id')
+    dream_run_parser.add_argument('--trigger-hb-id', help='Heartbeat id that triggered the dream run')
+    dream_run_parser.add_argument('--timeout', '-t', help='Override dream timeout (e.g., 10m, 1h)')
+
     timer_parser = subparsers.add_parser('timer', help='Schedule delayed agent-manager actions')
     timer_subparsers = timer_parser.add_subparsers(dest='timer_command', help='Timer commands')
 

--- a/agent-manager/scripts/command_registry.py
+++ b/agent-manager/scripts/command_registry.py
@@ -14,6 +14,7 @@ def get_command_handlers(
     cmd_assign: Callable,
     cmd_schedule: Callable,
     cmd_heartbeat: Callable,
+    cmd_dream: Callable,
     cmd_timer: Callable,
     cmd_inbound: Callable,
 ) -> dict[str, Callable]:
@@ -28,6 +29,7 @@ def get_command_handlers(
         'assign': cmd_assign,
         'schedule': cmd_schedule,
         'heartbeat': cmd_heartbeat,
+        'dream': cmd_dream,
         'timer': cmd_timer,
         'inbound': cmd_inbound,
     }

--- a/agent-manager/scripts/commands/__init__.py
+++ b/agent-manager/scripts/commands/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .dream import cmd_dream
 from .doctor import cmd_doctor
 from .heartbeat import cmd_heartbeat
 from .inbound import cmd_inbound
@@ -19,6 +20,7 @@ __all__ = [
     'cmd_send',
     'cmd_assign',
     'cmd_doctor',
+    'cmd_dream',
     'cmd_list',
     'cmd_status',
     'cmd_schedule',

--- a/agent-manager/scripts/commands/dream.py
+++ b/agent-manager/scripts/commands/dream.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Callable
+
+
+def cmd_dream(
+    args,
+    *,
+    run_handler: Callable,
+):
+    """Handle dream subcommands."""
+    if args.dream_command == 'run':
+        return run_handler(args)
+
+    print(f"Unknown dream command: {args.dream_command}")
+    return 1

--- a/agent-manager/scripts/commands/status.py
+++ b/agent-manager/scripts/commands/status.py
@@ -12,6 +12,14 @@ def _heartbeat_audit_path(repo_root, agent_id: str):
     return repo_root / '.claude' / 'state' / 'agent-manager' / 'heartbeat-audit' / f"{agent_id}.jsonl"
 
 
+def _dream_audit_path(repo_root, agent_id: str):
+    return repo_root / '.claude' / 'state' / 'agent-manager' / 'dream-audit' / f"{agent_id}.jsonl"
+
+
+def _dream_state_path(repo_root, agent_id: str):
+    return repo_root / '.claude' / 'state' / 'agent-manager' / 'dream-state' / f"{agent_id}.json"
+
+
 def _load_recent_heartbeat_event(repo_root, agent_id: str) -> Optional[dict]:
     audit_file = _heartbeat_audit_path(repo_root, agent_id)
     if not audit_file.exists():
@@ -34,6 +42,41 @@ def _load_recent_heartbeat_event(repo_root, agent_id: str) -> Optional[dict]:
             return payload
 
     return None
+
+
+def _load_recent_dream_event(repo_root, agent_id: str) -> Optional[dict]:
+    audit_file = _dream_audit_path(repo_root, agent_id)
+    if not audit_file.exists():
+        return None
+
+    try:
+        lines = audit_file.read_text(encoding='utf-8').splitlines()
+    except Exception:
+        return None
+
+    for raw in reversed(lines):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(payload, dict):
+            return payload
+
+    return None
+
+
+def _load_dream_state(repo_root, agent_id: str) -> Optional[dict]:
+    path = _dream_state_path(repo_root, agent_id)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _extract_recent_hb_id_from_output(output: str) -> str:
@@ -92,6 +135,8 @@ def cmd_status(args, *, deps: Any):
 
     recent_heartbeat = "none"
     recent_heartbeat_detail = ""
+    recent_dream = "none"
+    dream_window = "none"
 
     repo_root = get_repo_root()
     event = _load_recent_heartbeat_event(repo_root, agent_id)
@@ -113,6 +158,16 @@ def cmd_status(args, *, deps: Any):
         if hb_id:
             recent_heartbeat = f"{hb_id} (from tmux output)"
 
+    dream_event = _load_recent_dream_event(repo_root, agent_id)
+    dream_state = _load_dream_state(repo_root, agent_id)
+    if dream_event:
+        recent_dream = str(dream_event.get('event') or 'recorded')
+        if dream_event.get('dream_id'):
+            recent_dream += f" ({dream_event.get('dream_id')})"
+    if dream_state and dream_state.get('window_id'):
+        status = 'triggered' if dream_state.get('triggered_for_window') else 'active'
+        dream_window = f"{dream_state.get('window_id')} ({status})"
+
     print(f"📌 Status: {agent_name}")
     print(f"   Agent ID: {agent_id}")
     print(f"   Enabled: {'yes' if enabled else 'no'}")
@@ -126,5 +181,7 @@ def cmd_status(args, *, deps: Any):
     print(f"   Recent heartbeat: {recent_heartbeat}")
     if recent_heartbeat_detail:
         print(f"   Heartbeat detail: {recent_heartbeat_detail}")
+    print(f"   Recent dream: {recent_dream}")
+    print(f"   Dream window: {dream_window}")
 
     return 0

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -85,6 +85,14 @@ from commands.inbound import (
     cmd_inbound as inbound_cmd_inbound,
     drain_main_inbound_once as inbound_drain_main_inbound_once,
 )
+from commands.dream import cmd_dream as dream_cmd_dream
+from services.dream_state import (
+    append_dream_audit_event,
+    load_dream_state,
+    parse_iso8601_utc as dream_parse_iso8601_utc,
+    process_heartbeat_for_dream,
+    save_dream_state,
+)
 from services.heartbeat_service import (
     notify_heartbeat_failure as service_notify_heartbeat_failure,
     parse_heartbeat_recovery_policy as service_parse_heartbeat_recovery_policy,
@@ -706,6 +714,7 @@ _HEARTBEAT_FALLBACK_MODES = {"none", "fresh"}
 _HEARTBEAT_RECOVERY_FAILURE_TYPES = set(SERVICE_RECOVERABLE_FAILURE_TYPES)
 _CONTEXT_LEFT_PATTERN_CACHE: dict[str, list[re.Pattern]] = {}
 _HEARTBEAT_TRACE_MAX_LIMIT = 5000
+_DREAM_ID_PATTERN = re.compile(r"\[DREAM_ID:([^\]\s]+)\]")
 _HEARTBEAT_AUTO_STARVATION_SKIP_THRESHOLD = 3
 _HEARTBEAT_AUTO_STARVATION_LOOKBACK_LIMIT = 32
 
@@ -968,24 +977,7 @@ def _utc_now_iso() -> str:
 
 
 def _parse_iso8601_utc(value: object) -> Optional[datetime]:
-    text = str(value or '').strip()
-    if not text:
-        return None
-
-    normalized = text
-    if normalized.endswith('Z'):
-        normalized = normalized[:-1] + '+00:00'
-
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except Exception:
-        return None
-
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    else:
-        parsed = parsed.astimezone(timezone.utc)
-    return parsed
+    return dream_parse_iso8601_utc(value)
 
 
 def _heartbeat_result(*, send_status: str, ack_status: str, failure_type: str) -> str:
@@ -1054,6 +1046,7 @@ def _append_heartbeat_audit_event(
     attempt: int = 0,
     recovery_action: str = "",
     reason_code: str = "",
+    ack_evidence: str = "",
     timestamp: Optional[str] = None,
 ) -> Path:
     audit_file = _heartbeat_audit_file(repo_root, agent_id)
@@ -1077,6 +1070,7 @@ def _append_heartbeat_audit_event(
         'attempt': int(max(0, attempt)),
         'recovery_action': str(recovery_action or ''),
         'reason_code': str(reason_code or ''),
+        'ack_evidence': str(ack_evidence or ''),
     }
 
     with audit_file.open('a', encoding='utf-8') as fp:
@@ -1140,6 +1134,296 @@ def _read_heartbeat_audit_events(
 
     events.sort(key=lambda item: str(item.get('timestamp', '')), reverse=True)
     return events[:trace_limit]
+
+
+def _parse_dream_policy(heartbeat: dict) -> dict:
+    defaults = {
+        'enabled': False,
+        'idle_after': '1h',
+        'idle_after_seconds': 3600,
+        'max_runtime': '',
+        'max_runtime_seconds': None,
+    }
+    raw = heartbeat.get('dream') if isinstance(heartbeat, dict) else {}
+    if not isinstance(raw, dict):
+        return dict(defaults)
+
+    idle_after_text = str(raw.get('idle_after', defaults['idle_after']) or defaults['idle_after']).strip()
+    idle_after_seconds = parse_duration(idle_after_text) or defaults['idle_after_seconds']
+    max_runtime_text = str(raw.get('max_runtime', defaults['max_runtime']) or '').strip()
+    max_runtime_seconds = parse_duration(max_runtime_text) if max_runtime_text else None
+    return {
+        'enabled': bool(raw.get('enabled', defaults['enabled'])),
+        'idle_after': idle_after_text,
+        'idle_after_seconds': int(idle_after_seconds),
+        'max_runtime': max_runtime_text,
+        'max_runtime_seconds': max_runtime_seconds,
+    }
+
+
+def _parse_simple_cron_interval_seconds(cron_expr: str) -> Optional[int]:
+    text = str(cron_expr or '').strip()
+    if not text:
+        return None
+    parts = text.split()
+    if len(parts) != 5:
+        return None
+    minute, hour, day, month, weekday = parts
+    if minute.startswith('*/') and hour == '*' and day == '*' and month == '*' and weekday == '*':
+        try:
+            return int(minute[2:]) * 60
+        except Exception:
+            return None
+    if minute.isdigit() and hour.startswith('*/') and day == '*' and month == '*' and weekday == '*':
+        try:
+            return int(hour[2:]) * 3600
+        except Exception:
+            return None
+    if minute.isdigit() and hour.isdigit() and day.startswith('*/') and month == '*' and weekday == '*':
+        try:
+            return int(day[2:]) * 86400
+        except Exception:
+            return None
+    return None
+
+
+def _has_direct_dream_ack(output: str, dream_id: str) -> bool:
+    if not dream_id:
+        return False
+    marker = f"[DREAM_ID:{dream_id}]"
+    for line in str(output or '').splitlines():
+        if 'DREAM_OK' in line and marker in line:
+            return True
+    return False
+
+
+def _build_dream_prompt(*, dream_id: str, trigger_hb_id: str) -> str:
+    prompt = (
+        "Read DREAM.md if it exists (workspace context). Follow it strictly. "
+        "Do not infer or repeat old tasks from prior chats. "
+        "If nothing worth doing emerges, reply DREAM_OK. "
+        f"[DREAM_ID:{dream_id}]"
+    )
+    if trigger_hb_id:
+        prompt += f" [TRIGGER_HB_ID:{trigger_hb_id}]"
+    return prompt
+
+
+def _schedule_dream_run(
+    *,
+    agent_file_id: str,
+    window_id: str,
+    trigger_hb_id: str,
+    timeout_text: str,
+) -> int:
+    command_args = ['--', 'dream', 'run', agent_file_id, '--window-id', window_id, '--trigger-hb-id', trigger_hb_id]
+    if timeout_text:
+        command_args.extend(['--timeout', timeout_text])
+    timer_args = argparse.Namespace(
+        timer_command='command',
+        delay='1s',
+        command_args=command_args,
+    )
+    return cmd_timer(timer_args)
+
+
+def _maybe_trigger_dream_from_heartbeat(
+    *,
+    repo_root: Path,
+    agent_config: dict,
+    agent_id: str,
+    agent_file_id: str,
+    heartbeat: dict,
+    heartbeat_id: str,
+    heartbeat_timestamp: str,
+    ack_status: str,
+    ack_evidence: str,
+    failure_type: str,
+) -> None:
+    policy = _parse_dream_policy(heartbeat)
+    if not policy['enabled']:
+        return
+
+    state = load_dream_state(repo_root, agent_id)
+    processed = process_heartbeat_for_dream(
+        state=state,
+        agent_id=agent_id,
+        heartbeat_id=heartbeat_id,
+        heartbeat_timestamp=heartbeat_timestamp,
+        ack_status=ack_status,
+        ack_evidence=ack_evidence,
+        failure_type=failure_type,
+        idle_after_seconds=int(policy['idle_after_seconds']),
+        configured_heartbeat_interval_seconds=_parse_simple_cron_interval_seconds(heartbeat.get('cron', '')),
+    )
+    next_state = dict(processed['state'])
+    event = str(processed.get('event') or '')
+    reason_code = str(processed.get('reason_code') or '')
+    effective_idle_elapsed = int(processed.get('effective_idle_elapsed') or 0)
+    if event:
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event=event,
+            window_id=str(next_state.get('window_id') or ''),
+            hb_id=heartbeat_id,
+            reason_code=reason_code,
+            detail=f'ack={ack_status}:{ack_evidence}',
+            effective_idle_elapsed=effective_idle_elapsed,
+        )
+
+    if processed.get('should_trigger'):
+        working_dir = _normalize_path(agent_config.get('working_directory') or '')
+        dream_file = Path(working_dir) / 'DREAM.md' if working_dir else None
+        next_state['triggered_for_window'] = True
+        next_state['triggered_at'] = heartbeat_timestamp
+        next_state['triggered_by_hb_id'] = heartbeat_id
+        if not dream_file or not dream_file.exists():
+            append_dream_audit_event(
+                repo_root,
+                agent_id=agent_id,
+                event='trigger_skipped_no_dream_file',
+                window_id=str(next_state.get('window_id') or ''),
+                hb_id=heartbeat_id,
+                reason_code='DREAM_NO_FILE',
+                detail=str(dream_file or ''),
+                effective_idle_elapsed=effective_idle_elapsed,
+            )
+        else:
+            timer_rc = _schedule_dream_run(
+                agent_file_id=agent_file_id,
+                window_id=str(next_state.get('window_id') or ''),
+                trigger_hb_id=heartbeat_id,
+                timeout_text=str(policy.get('max_runtime') or ''),
+            )
+            if timer_rc == 0:
+                append_dream_audit_event(
+                    repo_root,
+                    agent_id=agent_id,
+                    event='trigger_scheduled',
+                    window_id=str(next_state.get('window_id') or ''),
+                    hb_id=heartbeat_id,
+                    reason_code='DREAM_TRIGGER_SCHEDULED',
+                    detail=f"idle_after={policy['idle_after']}",
+                    effective_idle_elapsed=effective_idle_elapsed,
+                )
+            else:
+                next_state['triggered_for_window'] = False
+                next_state['triggered_at'] = ''
+                next_state['triggered_by_hb_id'] = ''
+                append_dream_audit_event(
+                    repo_root,
+                    agent_id=agent_id,
+                    event='run_failed',
+                    window_id=str(next_state.get('window_id') or ''),
+                    hb_id=heartbeat_id,
+                    reason_code='DREAM_TRIGGER_SCHEDULE_FAILED',
+                    detail='timer_command_failed',
+                    effective_idle_elapsed=effective_idle_elapsed,
+                )
+
+    save_dream_state(repo_root, agent_id, next_state)
+
+
+def _run_dream_attempt(
+    *,
+    repo_root: Path,
+    agent_id: str,
+    agent_name: str,
+    launcher: str,
+    dream_message: str,
+    timeout_seconds: Optional[int],
+    is_codex: bool,
+    dream_id: str,
+) -> dict:
+    started = time.time()
+    baseline_output = capture_output(agent_id, lines=60) or ''
+    baseline_hash = _tail_hash(baseline_output)
+
+    if not send_keys(
+        agent_id,
+        dream_message,
+        send_enter=True,
+        clear_input=is_codex,
+        escape_first=is_codex,
+        enter_via_key=is_codex,
+    ):
+        return {
+            'send_status': 'fail',
+            'ack_status': 'not_checked',
+            'failure_type': 'send_fail',
+            'duration_ms': int((time.time() - started) * 1000),
+        }
+
+    waited_for_ack = bool(timeout_seconds and timeout_seconds > 0)
+    last_state: Optional[str] = None
+    activated = False
+    direct_ack = False
+    timed_out = False
+    if waited_for_ack:
+        start_time = time.time()
+        activation_timeout = min(60, int(timeout_seconds))
+        time.sleep(2)
+        while (time.time() - start_time) < activation_timeout:
+            if has_pending_inbound_messages(repo_root, agent_id=agent_id):
+                return {
+                    'send_status': 'ok',
+                    'ack_status': 'yielded',
+                    'failure_type': 'user_queue_yield',
+                    'duration_ms': int((time.time() - started) * 1000),
+                }
+            runtime = get_agent_runtime_state(agent_id, launcher=launcher)
+            last_state = str(runtime.get('state', 'unknown'))
+            current_output = capture_output(agent_id, lines=60) or ''
+            if _has_direct_dream_ack(current_output, dream_id):
+                direct_ack = True
+                activated = True
+                last_state = 'idle'
+                break
+            if last_state != 'idle' or _tail_hash(current_output) != baseline_hash:
+                activated = True
+                break
+            time.sleep(2)
+
+        if activated and not direct_ack:
+            while (time.time() - start_time) < int(timeout_seconds):
+                runtime = get_agent_runtime_state(agent_id, launcher=launcher)
+                last_state = str(runtime.get('state', 'unknown'))
+                current_output = capture_output(agent_id, lines=60) or ''
+                if _has_direct_dream_ack(current_output, dream_id):
+                    direct_ack = True
+                    last_state = 'idle'
+                    break
+                if last_state == 'idle':
+                    break
+                if last_state in {'blocked', 'error', 'stuck', 'interrupted'}:
+                    break
+                time.sleep(2)
+        if last_state != 'idle' and (time.time() - start_time) >= int(timeout_seconds):
+            timed_out = True
+
+    if direct_ack:
+        ack_status = 'ack'
+        failure_type = ''
+    elif waited_for_ack and timed_out:
+        ack_status = 'timeout'
+        failure_type = 'timeout'
+    elif waited_for_ack and last_state == 'idle':
+        ack_status = 'ack'
+        failure_type = ''
+    elif waited_for_ack:
+        ack_status = 'no_ack'
+        failure_type = 'no_ack'
+    else:
+        ack_status = 'not_checked'
+        failure_type = ''
+
+    return {
+        'send_status': 'ok',
+        'ack_status': ack_status,
+        'failure_type': failure_type,
+        'duration_ms': int((time.time() - started) * 1000),
+    }
 
 
 def _is_auto_preflight_skip_event(event: dict) -> bool:
@@ -1634,9 +1918,172 @@ def cmd_heartbeat(args):
     )
 
 
+def cmd_dream(args):
+    """Handle dream subcommands."""
+    return dream_cmd_dream(
+        args,
+        run_handler=cmd_dream_run,
+    )
+
+
 def cmd_timer(args):
     """Handle timer subcommands."""
     return timer_cmd_timer(args, deps=_lifecycle_deps_module())
+
+
+def cmd_dream_run(args):
+    """Run one dream task for an agent."""
+    if not check_tmux():
+        print("❌ tmux is not installed")
+        return 1
+
+    agent_config = resolve_agent(args.agent)
+    if not agent_config:
+        print(f"❌ Agent not found: {args.agent}")
+        return 1
+
+    agent_name = agent_config['name']
+    agent_id = get_agent_id(agent_config)
+    if not agent_config.get('enabled', True):
+        print(f"⏭️  Agent '{agent_name}' is disabled - skipping dream")
+        return 0
+
+    heartbeat = agent_config.get('heartbeat')
+    if not heartbeat or not isinstance(heartbeat, dict):
+        print(f"❌ No heartbeat configured for agent '{agent_name}'")
+        return 1
+
+    dream_policy = _parse_dream_policy(heartbeat)
+    if not dream_policy['enabled']:
+        print(f"⏭️  Dream mode is disabled for agent '{agent_name}'")
+        return 0
+
+    if not session_exists(agent_id):
+        print(f"⏭️  Agent '{agent_name}' is not running - skipping dream")
+        return 0
+
+    repo_root = get_repo_root()
+    state = load_dream_state(repo_root, agent_id)
+    expected_window_id = str(getattr(args, 'window_id', '') or '').strip()
+    trigger_hb_id = str(getattr(args, 'trigger_hb_id', '') or '').strip()
+    active_window_id = str(state.get('window_id') or '')
+    if expected_window_id and active_window_id != expected_window_id:
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_stale',
+            window_id=expected_window_id,
+            hb_id=trigger_hb_id,
+            reason_code='DREAM_STALE_WINDOW',
+            detail=f'active={active_window_id}',
+        )
+        print(f"⏭️  Dream window is stale (expected={expected_window_id}, active={active_window_id})")
+        return 0
+
+    working_dir = _normalize_path(agent_config.get('working_directory') or '')
+    dream_file = Path(working_dir) / 'DREAM.md' if working_dir else None
+    if not dream_file or not dream_file.exists():
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_stale',
+            window_id=active_window_id,
+            hb_id=trigger_hb_id,
+            reason_code='DREAM_NO_FILE',
+            detail=str(dream_file or ''),
+        )
+        print("⏭️  DREAM.md not found - skipping dream")
+        return 0
+
+    if has_pending_inbound_messages(repo_root, agent_id=agent_id):
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_stale',
+            window_id=active_window_id,
+            hb_id=trigger_hb_id,
+            reason_code='DREAM_USER_QUEUE_PENDING',
+            detail='pending_inbound_messages',
+        )
+        print("⏭️  Pending inbound user work detected - skipping dream")
+        return 0
+
+    launcher = resolve_launcher_command(agent_config.get('launcher', ''))
+    preflight_state, preflight_reason = _heartbeat_preflight_runtime_state(
+        agent_id=agent_id,
+        launcher=launcher,
+    )
+    if preflight_state != 'idle':
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_stale',
+            window_id=active_window_id,
+            hb_id=trigger_hb_id,
+            reason_code='DREAM_AGENT_NOT_IDLE',
+            detail=f'{preflight_state}:{preflight_reason}',
+        )
+        print(f"⏭️  Agent is not idle (state={preflight_state}, reason={preflight_reason}) - skipping dream")
+        return 0
+
+    timeout_text = str(getattr(args, 'timeout', '') or dream_policy.get('max_runtime') or '').strip()
+    timeout_seconds = parse_duration(timeout_text) if timeout_text else int(dream_policy.get('max_runtime_seconds') or 900)
+    if timeout_seconds is None:
+        timeout_seconds = 900
+
+    dream_id = time.strftime('%Y%m%d-%H%M%S')
+    dream_message = _build_dream_prompt(dream_id=dream_id, trigger_hb_id=trigger_hb_id)
+    append_dream_audit_event(
+        repo_root,
+        agent_id=agent_id,
+        event='run_started',
+        window_id=active_window_id,
+        hb_id=trigger_hb_id,
+        dream_id=dream_id,
+        reason_code='DREAM_RUN_STARTED',
+    )
+
+    result = _run_dream_attempt(
+        repo_root=repo_root,
+        agent_id=agent_id,
+        agent_name=agent_name,
+        launcher=launcher,
+        dream_message=dream_message,
+        timeout_seconds=timeout_seconds,
+        is_codex='codex' in launcher.lower(),
+        dream_id=dream_id,
+    )
+
+    send_status = str(result.get('send_status', 'fail'))
+    ack_status = str(result.get('ack_status', 'not_checked'))
+    failure_type = str(result.get('failure_type', ''))
+    if send_status == 'ok' and ack_status in {'ack', 'not_checked'} and not failure_type:
+        state['last_dream_id'] = dream_id
+        save_dream_state(repo_root, agent_id, state)
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_completed',
+            window_id=active_window_id,
+            hb_id=trigger_hb_id,
+            dream_id=dream_id,
+            reason_code='DREAM_RUN_OK',
+        )
+        print("✅ Dream completed successfully")
+        return 0
+
+    append_dream_audit_event(
+        repo_root,
+        agent_id=agent_id,
+        event='run_failed',
+        window_id=active_window_id,
+        hb_id=trigger_hb_id,
+        dream_id=dream_id,
+        reason_code='DREAM_RUN_FAILED',
+        detail=f'{send_status}:{ack_status}:{failure_type}',
+    )
+    print(f"❌ Dream failed (send={send_status}, ack={ack_status}, failure={failure_type or 'unknown'})")
+    return 1
 
 
 def cmd_heartbeat_run(args):
@@ -1729,6 +2176,18 @@ def cmd_heartbeat_run(args):
         context_left_percent=context_left_percent,
         session_mode=session_mode,
     ):
+        _maybe_trigger_dream_from_heartbeat(
+            repo_root=repo_root,
+            agent_config=agent_config,
+            agent_id=agent_id,
+            agent_file_id=agent_file_id,
+            heartbeat=heartbeat,
+            heartbeat_id=heartbeat_id,
+            heartbeat_timestamp=_utc_now_iso(),
+            ack_status='not_checked',
+            ack_evidence='none',
+            failure_type='inbound_queue_sweep',
+        )
         return 0
 
     if has_pending_inbound_messages(repo_root, agent_id=agent_id):
@@ -1754,6 +2213,19 @@ def cmd_heartbeat_run(args):
             attempt=0,
             recovery_action='yield_to_user',
             reason_code='HB_USER_QUEUE_PENDING',
+            ack_evidence='yielded',
+        )
+        _maybe_trigger_dream_from_heartbeat(
+            repo_root=repo_root,
+            agent_config=agent_config,
+            agent_id=agent_id,
+            agent_file_id=agent_file_id,
+            heartbeat=heartbeat,
+            heartbeat_id=heartbeat_id,
+            heartbeat_timestamp=_utc_now_iso(),
+            ack_status='yielded',
+            ack_evidence='yielded',
+            failure_type='user_queue_yield',
         )
         return 0
 
@@ -1807,6 +2279,19 @@ def cmd_heartbeat_run(args):
                     attempt=0,
                     recovery_action='skip_busy',
                     reason_code=skip_reason_code,
+                    ack_evidence='none',
+                )
+                _maybe_trigger_dream_from_heartbeat(
+                    repo_root=repo_root,
+                    agent_config=agent_config,
+                    agent_id=agent_id,
+                    agent_file_id=agent_file_id,
+                    heartbeat=heartbeat,
+                    heartbeat_id=heartbeat_id,
+                    heartbeat_timestamp=_utc_now_iso(),
+                    ack_status='not_checked',
+                    ack_evidence='none',
+                    failure_type=skip_failure_type,
                 )
                 return 0
     elif session_mode == 'force':
@@ -1881,6 +2366,7 @@ def cmd_heartbeat_run(args):
 
         send_status = str(result.get('send_status', 'fail'))
         ack_status = str(result.get('ack_status', 'not_checked'))
+        ack_evidence = str(result.get('ack_evidence', 'none'))
         failure_type = str(result.get('failure_type', ''))
         reason_code = str(result.get('reason_code', ''))
         duration_ms = int(result.get('duration_ms', 0) or 0)
@@ -1899,6 +2385,7 @@ def cmd_heartbeat_run(args):
             attempt=attempt_no,
             recovery_action=recovery_action,
             reason_code=reason_code,
+            ack_evidence=ack_evidence,
         )
 
         final_attempt_result = result
@@ -1912,6 +2399,18 @@ def cmd_heartbeat_run(args):
                 detail='heartbeat_wait_yield',
             )
             print("⏭️  Inbound user work arrived during heartbeat; yielding to user-first priority")
+            _maybe_trigger_dream_from_heartbeat(
+                repo_root=repo_root,
+                agent_config=agent_config,
+                agent_id=agent_id,
+                agent_file_id=agent_file_id,
+                heartbeat=heartbeat,
+                heartbeat_id=heartbeat_id,
+                heartbeat_timestamp=_utc_now_iso(),
+                ack_status=ack_status,
+                ack_evidence=ack_evidence,
+                failure_type=failure_type,
+            )
             return 0
 
         if send_status == 'ok' and ack_status in {'ack', 'not_checked'}:
@@ -1934,10 +2433,23 @@ def cmd_heartbeat_run(args):
 
     send_status = str(final_attempt_result.get('send_status', 'fail'))
     ack_status = str(final_attempt_result.get('ack_status', 'not_checked'))
+    ack_evidence = str(final_attempt_result.get('ack_evidence', 'none'))
     failure_type = str(final_attempt_result.get('failure_type', ''))
     reason_code = str(final_attempt_result.get('reason_code', ''))
 
     if send_status == 'ok' and ack_status in {'ack', 'not_checked'}:
+        _maybe_trigger_dream_from_heartbeat(
+            repo_root=repo_root,
+            agent_config=agent_config,
+            agent_id=agent_id,
+            agent_file_id=agent_file_id,
+            heartbeat=heartbeat,
+            heartbeat_id=heartbeat_id,
+            heartbeat_timestamp=_utc_now_iso(),
+            ack_status=ack_status,
+            ack_evidence=ack_evidence,
+            failure_type=failure_type,
+        )
         print("✅ Heartbeat completed successfully")
         return 0
 
@@ -1984,6 +2496,7 @@ def cmd_heartbeat_run(args):
             if fallback_result is not None:
                 send_status = str(fallback_result.get('send_status', 'fail'))
                 ack_status = str(fallback_result.get('ack_status', 'not_checked'))
+                ack_evidence = str(fallback_result.get('ack_evidence', 'none'))
                 failure_type = str(fallback_result.get('failure_type', ''))
                 reason_code = str(fallback_result.get('reason_code', ''))
                 duration_ms = int(fallback_result.get('duration_ms', 0) or 0)
@@ -2001,6 +2514,7 @@ def cmd_heartbeat_run(args):
                     attempt=max_retries + 2,
                     recovery_action=recovery_action,
                     reason_code=reason_code,
+                    ack_evidence=ack_evidence,
                 )
         else:
             send_status = 'fail'
@@ -2014,8 +2528,33 @@ def cmd_heartbeat_run(args):
             )
 
     if send_status == 'ok' and ack_status in {'ack', 'not_checked'}:
+        _maybe_trigger_dream_from_heartbeat(
+            repo_root=repo_root,
+            agent_config=agent_config,
+            agent_id=agent_id,
+            agent_file_id=agent_file_id,
+            heartbeat=heartbeat,
+            heartbeat_id=heartbeat_id,
+            heartbeat_timestamp=_utc_now_iso(),
+            ack_status=ack_status,
+            ack_evidence=ack_evidence,
+            failure_type=failure_type,
+        )
         print("✅ Heartbeat recovered via fallback policy")
         return 0
+
+    _maybe_trigger_dream_from_heartbeat(
+        repo_root=repo_root,
+        agent_config=agent_config,
+        agent_id=agent_id,
+        agent_file_id=agent_file_id,
+        heartbeat=heartbeat,
+        heartbeat_id=heartbeat_id,
+        heartbeat_timestamp=_utc_now_iso(),
+        ack_status=ack_status,
+        ack_evidence=ack_evidence,
+        failure_type=failure_type,
+    )
 
     if notify_on_failure:
         _notify_heartbeat_failure(
@@ -2057,6 +2596,7 @@ def main():
         cmd_assign=cmd_assign,
         cmd_schedule=cmd_schedule,
         cmd_heartbeat=cmd_heartbeat,
+        cmd_dream=cmd_dream,
         cmd_timer=cmd_timer,
         cmd_inbound=cmd_inbound,
     )

--- a/agent-manager/scripts/services/__init__.py
+++ b/agent-manager/scripts/services/__init__.py
@@ -14,6 +14,13 @@ from .heartbeat_state_machine import (
     failure_reason_code,
     should_retry_heartbeat_attempt,
 )
+from .dream_state import (
+    append_dream_audit_event,
+    load_dream_state,
+    parse_iso8601_utc,
+    process_heartbeat_for_dream,
+    save_dream_state,
+)
 from .work_schedule import (
     format_schedule_summary,
     is_within_work_schedule,
@@ -28,6 +35,11 @@ __all__ = [
     'restart_heartbeat_session_fresh',
     'run_heartbeat_attempt',
     'notify_heartbeat_failure',
+    'load_dream_state',
+    'save_dream_state',
+    'append_dream_audit_event',
+    'process_heartbeat_for_dream',
+    'parse_iso8601_utc',
     'format_schedule_summary',
     'is_within_work_schedule',
 ]

--- a/agent-manager/scripts/services/dream_state.py
+++ b/agent-manager/scripts/services/dream_state.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def parse_iso8601_utc(value: object) -> Optional[datetime]:
+    text = str(value or '').strip()
+    if not text:
+        return None
+
+    normalized = text[:-1] + '+00:00' if text.endswith('Z') else text
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except Exception:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def dream_state_file(repo_root: Path, agent_id: str) -> Path:
+    safe_agent_id = str(agent_id or 'unknown').strip().lower() or 'unknown'
+    return repo_root / '.claude' / 'state' / 'agent-manager' / 'dream-state' / f'{safe_agent_id}.json'
+
+
+def dream_audit_file(repo_root: Path, agent_id: str) -> Path:
+    safe_agent_id = str(agent_id or 'unknown').strip().lower() or 'unknown'
+    return repo_root / '.claude' / 'state' / 'agent-manager' / 'dream-audit' / f'{safe_agent_id}.jsonl'
+
+
+def _default_state(agent_id: str) -> dict[str, Any]:
+    return {
+        'agent_id': str(agent_id),
+        'window_id': '',
+        'window_started_at': '',
+        'window_started_by_hb_id': '',
+        'last_heartbeat_at': '',
+        'last_heartbeat_hb_id': '',
+        'last_direct_ok_at': '',
+        'last_direct_ok_hb_id': '',
+        'triggered_for_window': False,
+        'triggered_at': '',
+        'triggered_by_hb_id': '',
+        'last_reset_reason': '',
+        'last_dream_id': '',
+        'last_dream_timer_id': '',
+    }
+
+
+def load_dream_state(repo_root: Path, agent_id: str) -> dict[str, Any]:
+    path = dream_state_file(repo_root, agent_id)
+    state = _default_state(agent_id)
+    if not path.exists():
+        return state
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return state
+    if not isinstance(payload, dict):
+        return state
+    state.update(payload)
+    state['agent_id'] = str(agent_id)
+    return state
+
+
+def save_dream_state(repo_root: Path, agent_id: str, state: dict[str, Any]) -> Path:
+    path = dream_state_file(repo_root, agent_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _default_state(agent_id)
+    payload.update(state or {})
+    payload['agent_id'] = str(agent_id)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
+    return path
+
+
+def append_dream_audit_event(
+    repo_root: Path,
+    *,
+    agent_id: str,
+    event: str,
+    window_id: str = '',
+    hb_id: str = '',
+    dream_id: str = '',
+    reason_code: str = '',
+    detail: str = '',
+    timer_id: str = '',
+    effective_idle_elapsed: Optional[int] = None,
+) -> Path:
+    path = dream_audit_file(repo_root, agent_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        'timestamp': _utc_now_iso(),
+        'agent_id': str(agent_id),
+        'event': str(event or ''),
+        'window_id': str(window_id or ''),
+        'hb_id': str(hb_id or ''),
+        'dream_id': str(dream_id or ''),
+        'reason_code': str(reason_code or ''),
+        'detail': str(detail or ''),
+        'timer_id': str(timer_id or ''),
+    }
+    if isinstance(effective_idle_elapsed, int):
+        payload['effective_idle_elapsed'] = max(0, int(effective_idle_elapsed))
+    with path.open('a', encoding='utf-8') as fp:
+        fp.write(json.dumps(payload, ensure_ascii=False) + '\n')
+    return path
+
+
+def process_heartbeat_for_dream(
+    *,
+    state: dict[str, Any],
+    agent_id: str,
+    heartbeat_id: str,
+    heartbeat_timestamp: str,
+    ack_status: str,
+    ack_evidence: str,
+    failure_type: str,
+    idle_after_seconds: int,
+    configured_heartbeat_interval_seconds: Optional[int] = None,
+) -> dict[str, Any]:
+    direct_ok = str(ack_status or '') == 'ack' and str(ack_evidence or '') == 'direct_heartbeat_ok'
+    next_state = _default_state(agent_id)
+    next_state.update(state or {})
+    next_state['agent_id'] = str(agent_id)
+
+    current_time = parse_iso8601_utc(heartbeat_timestamp)
+    previous_hb_time = parse_iso8601_utc(next_state.get('last_heartbeat_at'))
+    window_started_at = parse_iso8601_utc(next_state.get('window_started_at'))
+    had_window = bool(next_state.get('window_id'))
+
+    if direct_ok:
+        if not had_window:
+            next_state['window_id'] = f'dream-window-{heartbeat_id}'
+            next_state['window_started_at'] = heartbeat_timestamp
+            next_state['window_started_by_hb_id'] = heartbeat_id
+            window_started_at = current_time
+            window_event = 'window_started'
+            window_reason = 'DREAM_WINDOW_STARTED'
+        else:
+            window_event = 'window_extended'
+            window_reason = 'DREAM_WINDOW_EXTENDED'
+
+        next_state['last_direct_ok_at'] = heartbeat_timestamp
+        next_state['last_direct_ok_hb_id'] = heartbeat_id
+        next_state['last_heartbeat_at'] = heartbeat_timestamp
+        next_state['last_heartbeat_hb_id'] = heartbeat_id
+        next_state['last_reset_reason'] = ''
+
+        window_elapsed = 0
+        interval_elapsed = 0
+        if current_time and window_started_at:
+            window_elapsed = max(0, int((current_time - window_started_at).total_seconds()))
+        if current_time and previous_hb_time:
+            interval_elapsed = max(0, int((current_time - previous_hb_time).total_seconds()))
+
+        effective_idle_elapsed = max(
+            window_elapsed,
+            interval_elapsed,
+            max(0, int(configured_heartbeat_interval_seconds or 0)),
+        )
+        should_trigger = effective_idle_elapsed >= max(1, int(idle_after_seconds)) and not bool(next_state.get('triggered_for_window'))
+        return {
+            'state': next_state,
+            'event': window_event,
+            'reason_code': window_reason,
+            'should_trigger': should_trigger,
+            'effective_idle_elapsed': effective_idle_elapsed,
+        }
+
+    next_state['window_id'] = ''
+    next_state['window_started_at'] = ''
+    next_state['window_started_by_hb_id'] = ''
+    next_state['last_direct_ok_at'] = ''
+    next_state['last_direct_ok_hb_id'] = ''
+    next_state['triggered_for_window'] = False
+    next_state['triggered_at'] = ''
+    next_state['triggered_by_hb_id'] = ''
+    next_state['last_heartbeat_at'] = heartbeat_timestamp
+    next_state['last_heartbeat_hb_id'] = heartbeat_id
+    next_state['last_reset_reason'] = str(failure_type or ack_status or ack_evidence or 'heartbeat_non_direct')
+
+    return {
+        'state': next_state,
+        'event': 'window_reset' if had_window else '',
+        'reason_code': 'DREAM_WINDOW_RESET' if had_window else '',
+        'should_trigger': False,
+        'effective_idle_elapsed': 0,
+    }

--- a/agent-manager/scripts/services/heartbeat_service.py
+++ b/agent-manager/scripts/services/heartbeat_service.py
@@ -238,6 +238,7 @@ def run_heartbeat_attempt(
         return {
             'send_status': 'fail',
             'ack_status': 'not_checked',
+            'ack_evidence': 'none',
             'failure_type': failure_type,
             'reason_code': failure_reason_code(failure_type=failure_type, send_status='fail', ack_status='not_checked'),
             'last_state': None,
@@ -270,6 +271,7 @@ def run_heartbeat_attempt(
                 return {
                     'send_status': 'ok',
                     'ack_status': 'yielded',
+                    'ack_evidence': 'yielded',
                     'failure_type': 'user_queue_yield',
                     'reason_code': 'HB_USER_QUEUE_YIELD',
                     'last_state': last_state,
@@ -338,6 +340,7 @@ def run_heartbeat_attempt(
                         return {
                             'send_status': 'ok',
                             'ack_status': 'yielded',
+                            'ack_evidence': 'yielded',
                             'failure_type': 'user_queue_yield',
                             'reason_code': 'HB_USER_QUEUE_YIELD',
                             'last_state': last_state,
@@ -399,6 +402,7 @@ def run_heartbeat_attempt(
     return {
         'send_status': 'ok',
         'ack_status': ack_status,
+        'ack_evidence': 'direct_heartbeat_ok' if direct_ack else ('idle_only' if ack_status == 'ack' else 'none'),
         'failure_type': failure_type,
         'reason_code': reason_code,
         'last_state': last_state,

--- a/agent-manager/scripts/tests/test_cli_modular_slice1.py
+++ b/agent-manager/scripts/tests/test_cli_modular_slice1.py
@@ -97,16 +97,18 @@ class CliModularSlice1Tests(unittest.TestCase):
             cmd_assign=main.cmd_assign,
             cmd_schedule=main.cmd_schedule,
             cmd_heartbeat=main.cmd_heartbeat,
+            cmd_dream=main.cmd_dream,
             cmd_timer=main.cmd_timer,
             cmd_inbound=main.cmd_inbound,
         )
         self.assertEqual(
             set(handlers.keys()),
-            {'list', 'doctor', 'start', 'stop', 'status', 'monitor', 'send', 'assign', 'schedule', 'heartbeat', 'timer', 'inbound'},
+            {'list', 'doctor', 'start', 'stop', 'status', 'monitor', 'send', 'assign', 'schedule', 'heartbeat', 'dream', 'timer', 'inbound'},
         )
         self.assertIs(handlers['start'], main.cmd_start)
         self.assertIs(handlers['status'], main.cmd_status)
         self.assertIs(handlers['heartbeat'], main.cmd_heartbeat)
+        self.assertIs(handlers['dream'], main.cmd_dream)
         self.assertIs(handlers['timer'], main.cmd_timer)
         self.assertIs(handlers['inbound'], main.cmd_inbound)
 

--- a/agent-manager/scripts/tests/test_dream_command.py
+++ b/agent-manager/scripts/tests/test_dream_command.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import main  # noqa: E402
+from commands.dream import cmd_dream  # noqa: E402
+from services.dream_state import save_dream_state  # noqa: E402
+
+
+class DreamCommandTests(unittest.TestCase):
+    def test_command_dispatch_unknown_subcommand(self):
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cmd_dream(argparse.Namespace(dream_command='nope'), run_handler=lambda _args: 0)
+        self.assertEqual(rc, 1)
+        self.assertIn('Unknown dream command', out.getvalue())
+
+    def test_main_dream_run_skips_stale_window(self):
+        temp_root = Path(tempfile.mkdtemp(prefix='agent-manager-dream-'))
+        work_dir = temp_root / 'workspace'
+        work_dir.mkdir(parents=True, exist_ok=True)
+        (work_dir / 'DREAM.md').write_text('dream here\n', encoding='utf-8')
+        save_dream_state(temp_root, 'main', {
+            'window_id': 'dream-window-HB-actual',
+        })
+        agent_config = {
+            'name': 'main',
+            'file_id': 'main',
+            'working_directory': str(work_dir),
+            'launcher': 'codex',
+            'heartbeat': {'enabled': True, 'dream': {'enabled': True}},
+            'enabled': True,
+        }
+
+        out = io.StringIO()
+        with redirect_stdout(out), \
+                patch('main.check_tmux', return_value=True), \
+                patch('main.resolve_agent', return_value=agent_config), \
+                patch('main.get_agent_id', return_value='main'), \
+                patch('main.session_exists', return_value=True), \
+                patch('main.get_repo_root', return_value=temp_root):
+            rc = main.cmd_dream_run(
+                argparse.Namespace(
+                    agent='main',
+                    window_id='dream-window-HB-old',
+                    trigger_hb_id='HB-1',
+                    timeout=None,
+                )
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertIn('stale', out.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
+++ b/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import main  # noqa: E402
+
+
+class DreamHeartbeatIntegrationTests(unittest.TestCase):
+    def test_heartbeat_schedules_dream_when_interval_exceeds_idle_after(self):
+        temp_root = Path(tempfile.mkdtemp(prefix='agent-manager-dream-heartbeat-'))
+        work_dir = temp_root / 'workspace'
+        work_dir.mkdir(parents=True, exist_ok=True)
+        (work_dir / 'DREAM.md').write_text('follow dream\n', encoding='utf-8')
+        agent_config = {
+            'name': 'main',
+            'file_id': 'main',
+            'working_directory': str(work_dir),
+            'launcher': 'codex',
+            'heartbeat': {
+                'enabled': True,
+                'cron': '0 */4 * * *',
+                'max_runtime': '8m',
+                'session_mode': 'auto',
+                'dream': {
+                    'enabled': True,
+                    'idle_after': '1h',
+                    'max_runtime': '15m',
+                },
+            },
+            'enabled': True,
+        }
+
+        out = io.StringIO()
+        with redirect_stdout(out), \
+                patch('main.check_tmux', return_value=True), \
+                patch('main.resolve_agent', return_value=agent_config), \
+                patch('main.get_agent_id', return_value='main'), \
+                patch('main.session_exists', return_value=True), \
+                patch('main.resolve_launcher_command', return_value='codex'), \
+                patch('main.get_repo_root', return_value=temp_root), \
+                patch('main._detect_agent_context_left_percent', return_value=None), \
+                patch('main._maybe_rollover_heartbeat_session', return_value=None), \
+                patch('main._maybe_run_main_inbound_heartbeat_sweep', return_value=False), \
+                patch('main.has_pending_inbound_messages', return_value=False), \
+                patch('main._heartbeat_preflight_runtime_state', return_value=('idle', 'ready')), \
+                patch('main._run_heartbeat_attempt', return_value={
+                    'send_status': 'ok',
+                    'ack_status': 'ack',
+                    'ack_evidence': 'direct_heartbeat_ok',
+                    'failure_type': '',
+                    'reason_code': 'HB_ACK_OK',
+                    'duration_ms': 1000,
+                }), \
+                patch('main.cmd_timer', return_value=0) as mock_cmd_timer:
+            rc = main.cmd_heartbeat_run(
+                argparse.Namespace(
+                    agent='main',
+                    timeout=None,
+                    retry=None,
+                    backoff_seconds=None,
+                    fallback_mode=None,
+                    notify_on_failure=False,
+                    notifier_channel=None,
+                )
+            )
+
+        self.assertEqual(rc, 0)
+        mock_cmd_timer.assert_called_once()
+        timer_args = mock_cmd_timer.call_args.args[0]
+        self.assertEqual(timer_args.timer_command, 'command')
+        self.assertIn('dream', timer_args.command_args)
+        state_file = temp_root / '.claude' / 'state' / 'agent-manager' / 'dream-state' / 'main.json'
+        payload = json.loads(state_file.read_text(encoding='utf-8'))
+        self.assertTrue(payload['triggered_for_window'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agent-manager/scripts/tests/test_dream_state.py
+++ b/agent-manager/scripts/tests/test_dream_state.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from services.dream_state import process_heartbeat_for_dream  # noqa: E402
+
+
+class DreamStateTests(unittest.TestCase):
+    def test_direct_ok_starts_window(self):
+        result = process_heartbeat_for_dream(
+            state={},
+            agent_id='main',
+            heartbeat_id='HB-1',
+            heartbeat_timestamp='2026-04-05T12:00:00Z',
+            ack_status='ack',
+            ack_evidence='direct_heartbeat_ok',
+            failure_type='',
+            idle_after_seconds=3600,
+            configured_heartbeat_interval_seconds=600,
+        )
+
+        self.assertEqual(result['event'], 'window_started')
+        self.assertFalse(result['should_trigger'])
+        self.assertEqual(result['state']['window_id'], 'dream-window-HB-1')
+        self.assertEqual(result['state']['last_direct_ok_hb_id'], 'HB-1')
+
+    def test_large_heartbeat_interval_can_trigger_on_first_direct_ok(self):
+        result = process_heartbeat_for_dream(
+            state={},
+            agent_id='main',
+            heartbeat_id='HB-1',
+            heartbeat_timestamp='2026-04-05T12:00:00Z',
+            ack_status='ack',
+            ack_evidence='direct_heartbeat_ok',
+            failure_type='',
+            idle_after_seconds=3600,
+            configured_heartbeat_interval_seconds=4 * 3600,
+        )
+
+        self.assertTrue(result['should_trigger'])
+        self.assertEqual(result['effective_idle_elapsed'], 4 * 3600)
+
+    def test_non_direct_ok_resets_window(self):
+        result = process_heartbeat_for_dream(
+            state={
+                'window_id': 'dream-window-HB-1',
+                'window_started_at': '2026-04-05T11:00:00Z',
+                'triggered_for_window': True,
+            },
+            agent_id='main',
+            heartbeat_id='HB-2',
+            heartbeat_timestamp='2026-04-05T12:00:00Z',
+            ack_status='not_checked',
+            ack_evidence='none',
+            failure_type='busy_skip',
+            idle_after_seconds=3600,
+        )
+
+        self.assertEqual(result['event'], 'window_reset')
+        self.assertFalse(result['should_trigger'])
+        self.assertEqual(result['state']['window_id'], '')
+        self.assertFalse(result['state']['triggered_for_window'])
+        self.assertEqual(result['state']['last_reset_reason'], 'busy_skip')
+
+    def test_triggered_window_does_not_retrigger(self):
+        result = process_heartbeat_for_dream(
+            state={
+                'window_id': 'dream-window-HB-1',
+                'window_started_at': '2026-04-05T11:00:00Z',
+                'last_heartbeat_at': '2026-04-05T11:30:00Z',
+                'triggered_for_window': True,
+            },
+            agent_id='main',
+            heartbeat_id='HB-2',
+            heartbeat_timestamp='2026-04-05T12:00:00Z',
+            ack_status='ack',
+            ack_evidence='direct_heartbeat_ok',
+            failure_type='',
+            idle_after_seconds=1800,
+            configured_heartbeat_interval_seconds=600,
+        )
+
+        self.assertEqual(result['event'], 'window_extended')
+        self.assertFalse(result['should_trigger'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agent-manager/scripts/tests/test_status_command.py
+++ b/agent-manager/scripts/tests/test_status_command.py
@@ -34,11 +34,18 @@ class StatusCommandTests(unittest.TestCase):
     def test_status_running_uses_recent_audit_event(self):
         agent_config = {'name': 'dev', 'file_id': 'EMP_0001', 'enabled': True, 'launcher': 'codex'}
         audit_file = self.temp_root / '.claude' / 'state' / 'agent-manager' / 'heartbeat-audit' / 'emp-0001.jsonl'
+        dream_audit = self.temp_root / '.claude' / 'state' / 'agent-manager' / 'dream-audit' / 'emp-0001.jsonl'
+        dream_state = self.temp_root / '.claude' / 'state' / 'agent-manager' / 'dream-state' / 'emp-0001.json'
         audit_file.parent.mkdir(parents=True, exist_ok=True)
+        dream_audit.parent.mkdir(parents=True, exist_ok=True)
+        dream_state.parent.mkdir(parents=True, exist_ok=True)
         with audit_file.open('w', encoding='utf-8') as f:
             f.write('not-json\n')
             f.write(json.dumps({'hb_id': 'HB-1', 'timestamp': '2026-02-09T09:00:00Z', 'send_status': 'ok', 'ack_status': 'ack'}) + '\n')
             f.write(json.dumps({'hb_id': 'HB-2', 'timestamp': '2026-02-09T09:10:00Z', 'send_status': 'ok', 'ack_status': 'timeout'}) + '\n')
+        with dream_audit.open('w', encoding='utf-8') as f:
+            f.write(json.dumps({'event': 'run_completed', 'dream_id': 'DREAM-1'}) + '\n')
+        dream_state.write_text(json.dumps({'window_id': 'dream-window-HB-2', 'triggered_for_window': True}), encoding='utf-8')
 
         with patch('main.check_tmux', return_value=True), \
                 patch('main.resolve_agent', return_value=agent_config), \
@@ -56,6 +63,8 @@ class StatusCommandTests(unittest.TestCase):
         self.assertIn('Runtime elapsed: 14s', text)
         self.assertIn('Recent heartbeat: HB-2 (2026-02-09T09:10:00Z)', text)
         self.assertIn('Heartbeat detail: send=ok ack=timeout', text)
+        self.assertIn('Recent dream: run_completed (DREAM-1)', text)
+        self.assertIn('Dream window: dream-window-HB-2 (triggered)', text)
 
     def test_status_running_falls_back_to_tmux_output_hb_id(self):
         agent_config = {'name': 'qa', 'file_id': 'EMP_0002', 'enabled': True, 'launcher': 'codex'}


### PR DESCRIPTION
## Summary
- add configurable dream mode state + audit flow for main agent
- trigger dream scheduling from heartbeat direct `HEARTBEAT_OK` windows, including the case where heartbeat interval exceeds `idle_after`
- expose `dream run` and status output so operators can inspect/execute dream behavior directly

## Testing
- python3 -m unittest agent-manager.scripts.tests.test_dream_command agent-manager.scripts.tests.test_dream_heartbeat_integration agent-manager.scripts.tests.test_dream_state agent-manager.scripts.tests.test_status_command agent-manager.scripts.tests.test_heartbeat_command -v

Closes #149
