### PR TITLE
feat: add fixed Dream heartbeat windows

### DIFF
--- a/agent-manager/SKILL.md
+++ b/agent-manager/SKILL.md
@@ -416,6 +416,14 @@ heartbeat:
   max_runtime: 5m
   session_mode: auto     # restore | auto | fresh
   mode: normal           # normal (use `timer` for delayed rescue; `full_speed` is legacy)
+  dream:
+    enabled: true
+    idle_after: 1h       # Optional idle-window trigger after normal HEARTBEAT_OK cycles
+    max_runtime: 30m
+    fixed_windows:       # During these windows heartbeat dispatch sends DREAM.md tasks
+      - timezone: Asia/Shanghai
+        start: "23:00"
+        end: "08:00"
   enabled: true
 ---
 ```
@@ -429,9 +437,25 @@ heartbeat:
 | `session_mode` | string | | Session policy: `restore` (default), `auto` (rollover when context <25%), `fresh` (always rollover after handoff) |
 | `mode` | string | | Heartbeat trigger mode. `normal` is the only active path. `full_speed` is a deprecated compatibility value that only preserves legacy Codex hook cleanup/readback during `start`; timer-driven follow-up is the supported replacement. |
 | `auto_starvation_skip_threshold` | int | | `auto` mode only. Default `3`; set `0` to disable the forced-dispatch starvation bypass after consecutive preflight skips |
+| `dream` | dict | | Optional Dream mode policy. `idle_after` preserves the existing post-heartbeat Dream timer behavior; `fixed_windows` switches heartbeat dispatch to a Dream task while any configured window is active. |
 | `enabled` | bool | | Default: `true` |
 
 `full_speed` should now be treated as a legacy compatibility marker, not a canonical execution path. If an older Codex Stop hook is still present, `start` will clean it up; new delayed follow-up / rescue flows should use `timer`.
+
+### Fixed Dream Windows
+
+When `heartbeat.dream.enabled` is true and the current wall-clock time is inside
+any `heartbeat.dream.fixed_windows` rule, `heartbeat run` sends the standard
+Dream prompt instead of the standard heartbeat prompt:
+
+```
+Read DREAM.md if it exists ... If nothing worth doing emerges, reply DREAM_OK.
+```
+
+Fixed windows support `timezone`, `start`, `end`, `work_days`, `holidays`,
+`extra_workdays`, and `when`. Overnight ranges are supported (`23:00` →
+`08:00`). If `work_days` is omitted, fixed Dream windows default to all seven
+days. Multiple windows are OR rules: the first active window wins.
 
 ### Heartbeat vs Schedules
 

--- a/agent-manager/scripts/agent_config.py
+++ b/agent-manager/scripts/agent_config.py
@@ -999,6 +999,7 @@ def list_all_heartbeats(agents_dir: Optional[Path] = None) -> List[Dict[str, Any
             'mode': heartbeat.get('mode', 'normal'),
             'enabled': heartbeat.get('enabled', True),
             'schedule': heartbeat.get('schedule'),
+            'dream': heartbeat.get('dream'),
         })
 
     return all_heartbeats

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -8,6 +8,7 @@ Sessions are named: agent-{agent_id} where agent_id is file_id in lowercase (e.g
 
 from __future__ import annotations
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -1456,6 +1457,10 @@ def _has_direct_dream_ack(output: str, dream_id: str) -> bool:
         if 'DREAM_OK' in line and marker in line:
             return True
     return False
+
+
+def _tail_hash(output: str) -> str:
+    return hashlib.sha1(str(output or '').encode('utf-8')).hexdigest()
 
 
 def _build_dream_prompt(*, dream_id: str, trigger_hb_id: str) -> str:

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -93,6 +93,7 @@ from services.dream_state import (
     process_heartbeat_for_dream,
     save_dream_state,
 )
+from services.dream_window import normalize_dream_fixed_windows, resolve_active_dream_window
 from services.heartbeat_service import (
     notify_heartbeat_failure as service_notify_heartbeat_failure,
     parse_heartbeat_recovery_policy as service_parse_heartbeat_recovery_policy,
@@ -1400,6 +1401,7 @@ def _parse_dream_policy(heartbeat: dict) -> dict:
         'idle_after_seconds': 3600,
         'max_runtime': '',
         'max_runtime_seconds': None,
+        'fixed_windows': [],
     }
     raw = heartbeat.get('dream') if isinstance(heartbeat, dict) else {}
     if not isinstance(raw, dict):
@@ -1409,12 +1411,14 @@ def _parse_dream_policy(heartbeat: dict) -> dict:
     idle_after_seconds = parse_duration(idle_after_text) or defaults['idle_after_seconds']
     max_runtime_text = str(raw.get('max_runtime', defaults['max_runtime']) or '').strip()
     max_runtime_seconds = parse_duration(max_runtime_text) if max_runtime_text else None
+    fixed_windows = normalize_dream_fixed_windows(raw)
     return {
         'enabled': bool(raw.get('enabled', defaults['enabled'])),
         'idle_after': idle_after_text,
         'idle_after_seconds': int(idle_after_seconds),
         'max_runtime': max_runtime_text,
         'max_runtime_seconds': max_runtime_seconds,
+        'fixed_windows': fixed_windows,
     }
 
 
@@ -1466,6 +1470,23 @@ def _build_dream_prompt(*, dream_id: str, trigger_hb_id: str) -> str:
     return prompt
 
 
+def _dream_reason_code(*, send_status: str, ack_status: str, failure_type: str) -> str:
+    if str(send_status or '') != 'ok':
+        return 'DREAM_SEND_FAILED'
+    if str(ack_status or '') == 'ack':
+        return 'DREAM_ACK_OK'
+    if str(ack_status or '') == 'not_checked':
+        return 'DREAM_NOT_CHECKED'
+    failure = str(failure_type or '').strip()
+    if failure == 'timeout':
+        return 'DREAM_TIMEOUT'
+    if failure == 'user_queue_yield':
+        return 'DREAM_USER_QUEUE_YIELD'
+    if failure:
+        return f"DREAM_{failure.upper()}"
+    return 'DREAM_NO_ACK'
+
+
 def _schedule_dream_run(
     *,
     agent_file_id: str,
@@ -1499,6 +1520,9 @@ def _maybe_trigger_dream_from_heartbeat(
 ) -> None:
     policy = _parse_dream_policy(heartbeat)
     if not policy['enabled']:
+        return
+    fixed_window = resolve_active_dream_window(policy)
+    if fixed_window.get('active'):
         return
 
     state = load_dream_state(repo_root, agent_id)
@@ -1605,10 +1629,17 @@ def _run_dream_attempt(
         escape_first=is_codex,
         enter_via_key=is_codex,
     ):
+        failure_type = 'send_fail'
         return {
             'send_status': 'fail',
             'ack_status': 'not_checked',
+            'ack_evidence': 'none',
             'failure_type': 'send_fail',
+            'reason_code': _dream_reason_code(
+                send_status='fail',
+                ack_status='not_checked',
+                failure_type=failure_type,
+            ),
             'duration_ms': int((time.time() - started) * 1000),
         }
 
@@ -1626,7 +1657,13 @@ def _run_dream_attempt(
                 return {
                     'send_status': 'ok',
                     'ack_status': 'yielded',
+                    'ack_evidence': 'yielded',
                     'failure_type': 'user_queue_yield',
+                    'reason_code': _dream_reason_code(
+                        send_status='ok',
+                        ack_status='yielded',
+                        failure_type='user_queue_yield',
+                    ),
                     'duration_ms': int((time.time() - started) * 1000),
                 }
             runtime = get_agent_runtime_state(agent_id, launcher=launcher)
@@ -1661,26 +1698,189 @@ def _run_dream_attempt(
 
     if direct_ack:
         ack_status = 'ack'
+        ack_evidence = 'direct_dream_ok'
         failure_type = ''
     elif waited_for_ack and timed_out:
         ack_status = 'timeout'
+        ack_evidence = 'none'
         failure_type = 'timeout'
     elif waited_for_ack and last_state == 'idle':
         ack_status = 'ack'
+        ack_evidence = 'idle_only'
         failure_type = ''
     elif waited_for_ack:
         ack_status = 'no_ack'
+        ack_evidence = 'none'
         failure_type = 'no_ack'
     else:
         ack_status = 'not_checked'
+        ack_evidence = 'none'
         failure_type = ''
 
     return {
         'send_status': 'ok',
         'ack_status': ack_status,
+        'ack_evidence': ack_evidence,
         'failure_type': failure_type,
+        'reason_code': _dream_reason_code(
+            send_status='ok',
+            ack_status=ack_status,
+            failure_type=failure_type,
+        ),
         'duration_ms': int((time.time() - started) * 1000),
     }
+
+
+def _run_fixed_dream_heartbeat(
+    *,
+    repo_root: Path,
+    agent_config: dict,
+    agent_id: str,
+    agent_name: str,
+    dream_policy: dict,
+    heartbeat_id: str,
+    rollover_handoff_file: Optional[Path],
+    fixed_window: dict,
+    fallback_timeout_seconds: Optional[int] = None,
+) -> dict:
+    """Dispatch a Dream task from a heartbeat fixed window."""
+    fixed_window_id = str(fixed_window.get('window_id') or f'fixed-window-{heartbeat_id}')
+    fixed_window_summary = str(fixed_window.get('summary') or '')
+
+    working_dir = _normalize_path(agent_config.get('working_directory') or '')
+    dream_file = Path(working_dir) / 'DREAM.md' if working_dir else None
+    if not dream_file or not dream_file.exists():
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_stale',
+            window_id=fixed_window_id,
+            hb_id=heartbeat_id,
+            reason_code='DREAM_NO_FILE',
+            detail=str(dream_file or ''),
+        )
+        print("⏭️  DREAM.md not found - skipping fixed Dream window")
+        return {
+            'send_status': 'skip',
+            'ack_status': 'skipped',
+            'ack_evidence': 'none',
+            'failure_type': 'dream_no_file',
+            'reason_code': 'DREAM_NO_FILE',
+            'duration_ms': 0,
+            'dream_id': '',
+            'window_id': fixed_window_id,
+            'ran': False,
+        }
+
+    if has_pending_inbound_messages(repo_root, agent_id=agent_id):
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_stale',
+            window_id=fixed_window_id,
+            hb_id=heartbeat_id,
+            reason_code='DREAM_USER_QUEUE_PENDING',
+            detail='pending_inbound_messages',
+        )
+        print("⏭️  Pending inbound user work detected - skipping fixed Dream window")
+        return {
+            'send_status': 'ok',
+            'ack_status': 'yielded',
+            'ack_evidence': 'yielded',
+            'failure_type': 'user_queue_yield',
+            'reason_code': 'DREAM_USER_QUEUE_PENDING',
+            'duration_ms': 0,
+            'dream_id': '',
+            'window_id': fixed_window_id,
+            'ran': False,
+        }
+
+    launcher = resolve_launcher_command(agent_config.get('launcher', ''))
+    timeout_text = str(dream_policy.get('max_runtime') or '').strip()
+    timeout_seconds = (
+        parse_duration(timeout_text)
+        if timeout_text
+        else int(dream_policy.get('max_runtime_seconds') or fallback_timeout_seconds or 900)
+    )
+    if timeout_seconds is None:
+        timeout_seconds = 900
+
+    dream_id = time.strftime('%Y%m%d-%H%M%S')
+    dream_message = _build_dream_prompt(dream_id=dream_id, trigger_hb_id=heartbeat_id)
+    if rollover_handoff_file is not None:
+        dream_message = f"First read rollover handoff file: {rollover_handoff_file}.\n" + dream_message
+
+    append_dream_audit_event(
+        repo_root,
+        agent_id=agent_id,
+        event='run_started',
+        window_id=fixed_window_id,
+        hb_id=heartbeat_id,
+        dream_id=dream_id,
+        reason_code='DREAM_FIXED_WINDOW_STARTED',
+        detail=fixed_window_summary,
+    )
+
+    result = _run_dream_attempt(
+        repo_root=repo_root,
+        agent_id=agent_id,
+        agent_name=agent_name,
+        launcher=launcher,
+        dream_message=dream_message,
+        timeout_seconds=timeout_seconds,
+        is_codex='codex' in launcher.lower(),
+        dream_id=dream_id,
+    )
+
+    send_status = str(result.get('send_status', 'fail'))
+    ack_status = str(result.get('ack_status', 'not_checked'))
+    ack_evidence = str(result.get('ack_evidence', 'none'))
+    failure_type = str(result.get('failure_type', ''))
+    reason_code = str(result.get('reason_code') or _dream_reason_code(
+        send_status=send_status,
+        ack_status=ack_status,
+        failure_type=failure_type,
+    ))
+    duration_ms = int(result.get('duration_ms', 0) or 0)
+
+    if send_status == 'ok' and ack_status in {'ack', 'not_checked'} and not failure_type:
+        state = load_dream_state(repo_root, agent_id)
+        state['last_dream_id'] = dream_id
+        save_dream_state(repo_root, agent_id, state)
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_completed',
+            window_id=fixed_window_id,
+            hb_id=heartbeat_id,
+            dream_id=dream_id,
+            reason_code='DREAM_FIXED_WINDOW_OK',
+        )
+        print("✅ Dream completed successfully (fixed heartbeat window)")
+        result['completed'] = True
+    else:
+        append_dream_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            event='run_failed',
+            window_id=fixed_window_id,
+            hb_id=heartbeat_id,
+            dream_id=dream_id,
+            reason_code='DREAM_FIXED_WINDOW_FAILED',
+            detail=f'{send_status}:{ack_status}:{failure_type}',
+        )
+        print(f"❌ Dream failed (send={send_status}, ack={ack_status}, failure={failure_type or 'unknown'})")
+        result['completed'] = False
+
+    result.update({
+        'ack_evidence': ack_evidence,
+        'reason_code': reason_code,
+        'duration_ms': duration_ms,
+        'dream_id': dream_id,
+        'window_id': fixed_window_id,
+        'ran': True,
+    })
+    return result
 
 
 def _is_auto_preflight_skip_event(event: dict) -> bool:
@@ -2487,6 +2687,13 @@ def cmd_heartbeat_run(args):
         print(f"⏭️  Heartbeat is disabled for agent '{agent_name}'")
         return 0
 
+    dream_policy = _parse_dream_policy(heartbeat)
+    fixed_dream_window = (
+        resolve_active_dream_window(dream_policy)
+        if dream_policy.get('enabled')
+        else {'active': False, 'reason': 'dream_disabled', 'windows': []}
+    )
+
     # Heartbeats only check running agents - don't start if not running
     if not session_exists(agent_id):
         print(f"⏭️  Agent '{agent_name}' is not running - skipping heartbeat")
@@ -2494,7 +2701,7 @@ def cmd_heartbeat_run(args):
 
     # Check work schedule
     schedule_config = heartbeat.get('schedule')
-    if schedule_config:
+    if schedule_config and not fixed_dream_window.get('active'):
         from services.work_schedule import is_within_work_schedule
         is_active, skip_reason = is_within_work_schedule(schedule_config)
         if not is_active:
@@ -2531,6 +2738,11 @@ def cmd_heartbeat_run(args):
         f"fallback={recovery_policy['fallback_mode']} "
         f"notify={recovery_policy['notify_on_failure']}"
     )
+    if fixed_dream_window.get('active'):
+        window_summary = str(fixed_dream_window.get('summary') or fixed_dream_window.get('window_id') or 'active')
+        print(f"   Dream window: {window_summary}")
+    elif dream_policy.get('fixed_windows'):
+        print(f"   Dream window: inactive ({fixed_dream_window.get('reason')})")
 
     # Standard heartbeat message (with traceable id for delivery debugging)
     heartbeat_id = _generate_heartbeat_id()
@@ -2726,6 +2938,55 @@ def cmd_heartbeat_run(args):
         heartbeat_id=heartbeat_id,
         session_mode=session_mode,
     )
+
+    if fixed_dream_window.get('active'):
+        dream_result = _run_fixed_dream_heartbeat(
+            repo_root=repo_root,
+            agent_config=agent_config,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            dream_policy=dream_policy,
+            heartbeat_id=heartbeat_id,
+            rollover_handoff_file=rollover_handoff_file,
+            fixed_window=fixed_dream_window,
+            fallback_timeout_seconds=timeout_seconds,
+        )
+        if not dream_result.get('ran'):
+            return 0
+
+        send_status = str(dream_result.get('send_status', 'fail'))
+        ack_status = str(dream_result.get('ack_status', 'not_checked'))
+        ack_evidence = str(dream_result.get('ack_evidence', 'none'))
+        failure_type = str(dream_result.get('failure_type', ''))
+        reason_code = str(dream_result.get('reason_code', ''))
+        duration_ms = int(dream_result.get('duration_ms', 0) or 0)
+
+        _append_heartbeat_audit_event(
+            repo_root,
+            agent_id=agent_id,
+            heartbeat_id=heartbeat_id,
+            send_status=send_status,
+            ack_status=ack_status,
+            duration_ms=duration_ms,
+            context_left=context_left_percent,
+            failure_type=failure_type,
+            session_mode=session_mode,
+            phase='attempt',
+            attempt=1,
+            recovery_action='dream_window',
+            reason_code=reason_code,
+            ack_evidence=ack_evidence,
+        )
+
+        if send_status == 'ok' and ack_status in {'ack', 'not_checked'} and not failure_type:
+            print("✅ Heartbeat completed via fixed Dream window")
+            return 0
+
+        print(
+            "❌ Fixed Dream window failed "
+            f"(send={send_status}, ack={ack_status}, failure={failure_type or 'unknown'})"
+        )
+        return 1
 
     heartbeat_message = (
         "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. "

--- a/agent-manager/scripts/main.py
+++ b/agent-manager/scripts/main.py
@@ -1454,13 +1454,29 @@ def _has_direct_dream_ack(output: str, dream_id: str) -> bool:
         return False
     marker = f"[DREAM_ID:{dream_id}]"
     for line in str(output or '').splitlines():
-        if 'DREAM_OK' in line and marker in line:
+        normalized = line.strip()
+        if 'DREAM_OK' not in normalized or marker not in normalized:
+            continue
+        lower = normalized.lower()
+        if 'reply dream_ok' in lower or 'read dream.md' in lower or 'if nothing worth doing' in lower:
+            continue
+        if re.search(r'(?:^|[\s•\-])DREAM_OK(?:[\s.!?]+|\s*)' + re.escape(marker), normalized):
             return True
     return False
 
 
 def _tail_hash(output: str) -> str:
     return hashlib.sha1(str(output or '').encode('utf-8')).hexdigest()
+
+
+def _dream_completion_evidence(output: str, *, dream_id: str, baseline_hash: str) -> str:
+    tail_hash = _tail_hash(output)
+    tail_short = tail_hash[:12]
+    if _has_direct_dream_ack(output, dream_id):
+        return f'direct_dream_ok:tail_sha1={tail_short}'
+    if tail_hash != baseline_hash:
+        return f'pane_tail_changed:tail_sha1={tail_short}'
+    return f'pane_tail_unchanged:tail_sha1={tail_short}'
 
 
 def _build_dream_prompt(*, dream_id: str, trigger_hb_id: str) -> str:
@@ -1625,6 +1641,7 @@ def _run_dream_attempt(
     started = time.time()
     baseline_output = capture_output(agent_id, lines=60) or ''
     baseline_hash = _tail_hash(baseline_output)
+    final_output = baseline_output
 
     if not send_keys(
         agent_id,
@@ -1674,6 +1691,7 @@ def _run_dream_attempt(
             runtime = get_agent_runtime_state(agent_id, launcher=launcher)
             last_state = str(runtime.get('state', 'unknown'))
             current_output = capture_output(agent_id, lines=60) or ''
+            final_output = current_output
             if _has_direct_dream_ack(current_output, dream_id):
                 direct_ack = True
                 activated = True
@@ -1689,6 +1707,7 @@ def _run_dream_attempt(
                 runtime = get_agent_runtime_state(agent_id, launcher=launcher)
                 last_state = str(runtime.get('state', 'unknown'))
                 current_output = capture_output(agent_id, lines=60) or ''
+                final_output = current_output
                 if _has_direct_dream_ack(current_output, dream_id):
                     direct_ack = True
                     last_state = 'idle'
@@ -1722,10 +1741,19 @@ def _run_dream_attempt(
         ack_evidence = 'none'
         failure_type = ''
 
+    completion_evidence = _dream_completion_evidence(
+        final_output,
+        dream_id=dream_id,
+        baseline_hash=baseline_hash,
+    )
+    if ack_status == 'ack' and ack_evidence == 'idle_only' and completion_evidence.startswith('pane_tail_changed:'):
+        ack_evidence = 'idle_after_output_change'
+
     return {
         'send_status': 'ok',
         'ack_status': ack_status,
         'ack_evidence': ack_evidence,
+        'completion_evidence': completion_evidence,
         'failure_type': failure_type,
         'reason_code': _dream_reason_code(
             send_status='ok',
@@ -1840,6 +1868,7 @@ def _run_fixed_dream_heartbeat(
     send_status = str(result.get('send_status', 'fail'))
     ack_status = str(result.get('ack_status', 'not_checked'))
     ack_evidence = str(result.get('ack_evidence', 'none'))
+    completion_evidence = str(result.get('completion_evidence', 'none'))
     failure_type = str(result.get('failure_type', ''))
     reason_code = str(result.get('reason_code') or _dream_reason_code(
         send_status=send_status,
@@ -1860,6 +1889,7 @@ def _run_fixed_dream_heartbeat(
             hb_id=heartbeat_id,
             dream_id=dream_id,
             reason_code='DREAM_FIXED_WINDOW_OK',
+            detail=f'ack={ack_status}:{ack_evidence}; completion={completion_evidence}',
         )
         print("✅ Dream completed successfully (fixed heartbeat window)")
         result['completed'] = True
@@ -1879,6 +1909,7 @@ def _run_fixed_dream_heartbeat(
 
     result.update({
         'ack_evidence': ack_evidence,
+        'completion_evidence': completion_evidence,
         'reason_code': reason_code,
         'duration_ms': duration_ms,
         'dream_id': dream_id,

--- a/agent-manager/scripts/schedule_helper.py
+++ b/agent-manager/scripts/schedule_helper.py
@@ -364,6 +364,13 @@ def list_heartbeats_formatted() -> str:
             if sched_summary:
                 details.append(f"sched:{sched_summary}")
 
+        dream = hb.get('dream')
+        if isinstance(dream, dict) and dream.get('enabled', False):
+            from services.dream_window import normalize_dream_fixed_windows
+            fixed_windows = normalize_dream_fixed_windows(dream)
+            if fixed_windows:
+                details.append(f"dream:{len(fixed_windows)}fixed")
+
         runtime_str = f"({' '.join(details)})" if details else ""
 
         lines.append(f"  {status} heartbeat           {cron:20} {runtime_str}")

--- a/agent-manager/scripts/services/__init__.py
+++ b/agent-manager/scripts/services/__init__.py
@@ -21,6 +21,10 @@ from .dream_state import (
     process_heartbeat_for_dream,
     save_dream_state,
 )
+from .dream_window import (
+    normalize_dream_fixed_windows,
+    resolve_active_dream_window,
+)
 from .work_schedule import (
     format_schedule_summary,
     is_within_work_schedule,
@@ -40,6 +44,8 @@ __all__ = [
     'append_dream_audit_event',
     'process_heartbeat_for_dream',
     'parse_iso8601_utc',
+    'normalize_dream_fixed_windows',
+    'resolve_active_dream_window',
     'format_schedule_summary',
     'is_within_work_schedule',
 ]

--- a/agent-manager/scripts/services/dream_window.py
+++ b/agent-manager/scripts/services/dream_window.py
@@ -1,0 +1,168 @@
+"""Fixed Dream window helpers.
+
+These helpers intentionally reuse the heartbeat work-schedule rule shape for
+timezone/day/holiday handling, but fixed Dream windows are OR-ed time windows:
+if any configured window is active, the heartbeat should dispatch a Dream task.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from .work_schedule import format_schedule_summary, is_within_work_schedule
+
+
+_ALL_DAYS = [1, 2, 3, 4, 5, 6, 7]
+_WINDOW_KEYS = (
+    "fixed_windows",
+    "fixed_window",
+    "windows",
+    "window",
+    "periods",
+    "period",
+)
+
+
+def normalize_dream_fixed_windows(dream_config: object) -> list[dict[str, Any]]:
+    """Normalize ``heartbeat.dream`` fixed window config into schedule rules.
+
+    Preferred shape::
+
+        dream:
+          enabled: true
+          fixed_windows:
+            - timezone: Asia/Shanghai
+              start: "23:00"
+              end: "08:00"
+
+    ``work_hours: {start, end}`` is also accepted. Unlike generic work
+    schedules, fixed Dream windows default to all seven days because sleep /
+    maintenance windows are usually daily unless explicitly constrained.
+    """
+    if not isinstance(dream_config, dict):
+        return []
+
+    raw_windows: list[Any] = []
+    for key in _WINDOW_KEYS:
+        value = dream_config.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            raw_windows.extend(value)
+        else:
+            raw_windows.append(value)
+
+    default_timezone = str(dream_config.get("timezone") or "").strip()
+    windows: list[dict[str, Any]] = []
+    for raw in raw_windows:
+        rule = _coerce_window_rule(raw, default_timezone=default_timezone)
+        if rule:
+            windows.append(rule)
+    return windows
+
+
+def resolve_active_dream_window(
+    dream_config: object,
+    *,
+    now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Return the active fixed Dream window, if any."""
+    windows = normalize_dream_fixed_windows(dream_config)
+    if not windows:
+        return {"active": False, "reason": "no_fixed_windows", "windows": []}
+
+    last_reason = "outside_fixed_windows"
+    for index, rule in enumerate(windows, start=1):
+        active, reason = is_within_work_schedule(rule, now=now)
+        if active:
+            return {
+                "active": True,
+                "index": index,
+                "rule": rule,
+                "summary": format_schedule_summary(rule),
+                "window_id": f"fixed-window-{index}",
+                "windows": windows,
+            }
+        if reason:
+            last_reason = reason
+
+    return {"active": False, "reason": last_reason, "windows": windows}
+
+
+def _coerce_window_rule(raw: Any, *, default_timezone: str = "") -> dict[str, Any]:
+    if isinstance(raw, str):
+        return _coerce_string_window(raw, default_timezone=default_timezone)
+    if not isinstance(raw, dict):
+        return {}
+
+    rule = dict(raw)
+    if default_timezone and not str(rule.get("timezone") or "").strip():
+        rule["timezone"] = default_timezone
+
+    if "work_hours" not in rule or not isinstance(rule.get("work_hours"), dict):
+        start = str(rule.pop("start", rule.pop("from", "")) or "").strip()
+        end = str(rule.pop("end", rule.pop("to", "")) or "").strip()
+        if start and end:
+            rule["work_hours"] = {"start": start, "end": end}
+
+    if not _has_valid_work_hours(rule):
+        return {}
+
+    if "work_days" not in rule:
+        days = rule.pop("days", rule.pop("weekdays", None))
+        rule["work_days"] = _normalize_days(days) if days is not None else list(_ALL_DAYS)
+
+    return rule
+
+
+def _coerce_string_window(raw: str, *, default_timezone: str = "") -> dict[str, Any]:
+    text = str(raw or "").strip()
+    if not text:
+        return {}
+
+    timezone = default_timezone
+    range_text = text
+    parts = text.split()
+    if len(parts) == 2:
+        timezone, range_text = parts[0], parts[1]
+
+    if "-" not in range_text:
+        return {}
+    start, end = [part.strip() for part in range_text.split("-", 1)]
+    if not start or not end:
+        return {}
+
+    rule: dict[str, Any] = {
+        "work_hours": {"start": start, "end": end},
+        "work_days": list(_ALL_DAYS),
+    }
+    if timezone:
+        rule["timezone"] = timezone
+    return rule
+
+
+def _has_valid_work_hours(rule: dict[str, Any]) -> bool:
+    work_hours = rule.get("work_hours")
+    if not isinstance(work_hours, dict):
+        return False
+    return bool(str(work_hours.get("start") or "").strip() and str(work_hours.get("end") or "").strip())
+
+
+def _normalize_days(raw: Any) -> list[int]:
+    if isinstance(raw, str):
+        items = [part.strip() for part in raw.split(",")]
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return list(_ALL_DAYS)
+
+    result: list[int] = []
+    for item in items:
+        try:
+            day = int(item)
+        except Exception:
+            continue
+        if 1 <= day <= 7 and day not in result:
+            result.append(day)
+    return result or list(_ALL_DAYS)

--- a/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
+++ b/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
@@ -168,6 +168,34 @@ class DreamHeartbeatIntegrationTests(unittest.TestCase):
         self.assertIn('[TRIGGER_HB_ID:', sent_message)
         self.assertIn('Heartbeat completed via fixed Dream window', out.getvalue())
 
+    def test_dream_attempt_hashes_tail_and_detects_direct_ack(self):
+        temp_root = Path(tempfile.mkdtemp(prefix='agent-manager-dream-attempt-'))
+        dream_id = 'DREAM-123'
+
+        with patch('main.capture_output', side_effect=[
+            'baseline output',
+            f'baseline output\n• DREAM_OK [DREAM_ID:{dream_id}]',
+        ]), \
+                patch('main.send_keys', return_value=True) as mock_send_keys, \
+                patch('main.has_pending_inbound_messages', return_value=False), \
+                patch('main.get_agent_runtime_state', return_value={'state': 'idle'}), \
+                patch('main.time.sleep', return_value=None):
+            result = main._run_dream_attempt(
+                repo_root=temp_root,
+                agent_id='main',
+                agent_name='main',
+                launcher='codex',
+                dream_message='Read DREAM.md',
+                timeout_seconds=5,
+                is_codex=True,
+                dream_id=dream_id,
+            )
+
+        self.assertEqual(result['send_status'], 'ok')
+        self.assertEqual(result['ack_status'], 'ack')
+        self.assertEqual(result['ack_evidence'], 'direct_dream_ok')
+        mock_send_keys.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
+++ b/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
@@ -141,6 +141,7 @@ class DreamHeartbeatIntegrationTests(unittest.TestCase):
                     'send_status': 'ok',
                     'ack_status': 'ack',
                     'ack_evidence': 'direct_dream_ok',
+                    'completion_evidence': 'direct_dream_ok:tail_sha1=abc123',
                     'failure_type': '',
                     'reason_code': 'DREAM_ACK_OK',
                     'duration_ms': 1000,
@@ -167,6 +168,26 @@ class DreamHeartbeatIntegrationTests(unittest.TestCase):
         self.assertIn('Read DREAM.md', sent_message)
         self.assertIn('[TRIGGER_HB_ID:', sent_message)
         self.assertIn('Heartbeat completed via fixed Dream window', out.getvalue())
+        audit_file = temp_root / '.claude' / 'state' / 'agent-manager' / 'dream-audit' / 'main.jsonl'
+        audit_events = [
+            json.loads(line)
+            for line in audit_file.read_text(encoding='utf-8').splitlines()
+        ]
+        completed = [event for event in audit_events if event.get('event') == 'run_completed']
+        self.assertEqual(len(completed), 1)
+        self.assertIn('completion=direct_dream_ok:tail_sha1=abc123', completed[0]['detail'])
+
+    def test_direct_dream_ack_ignores_prompt_echo(self):
+        dream_id = 'DREAM-123'
+        prompt_echo = (
+            "› Read DREAM.md if it exists. "
+            "If nothing worth doing emerges, reply DREAM_OK. "
+            f"[DREAM_ID:{dream_id}]"
+        )
+        final_reply = f"• DREAM_OK [DREAM_ID:{dream_id}]"
+
+        self.assertFalse(main._has_direct_dream_ack(prompt_echo, dream_id))
+        self.assertTrue(main._has_direct_dream_ack(final_reply, dream_id))
 
     def test_dream_attempt_hashes_tail_and_detects_direct_ack(self):
         temp_root = Path(tempfile.mkdtemp(prefix='agent-manager-dream-attempt-'))
@@ -194,6 +215,7 @@ class DreamHeartbeatIntegrationTests(unittest.TestCase):
         self.assertEqual(result['send_status'], 'ok')
         self.assertEqual(result['ack_status'], 'ack')
         self.assertEqual(result['ack_evidence'], 'direct_dream_ok')
+        self.assertTrue(result['completion_evidence'].startswith('direct_dream_ok:tail_sha1='))
         mock_send_keys.assert_called_once()
 
 

--- a/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
+++ b/agent-manager/scripts/tests/test_dream_heartbeat_integration.py
@@ -86,6 +86,88 @@ class DreamHeartbeatIntegrationTests(unittest.TestCase):
         payload = json.loads(state_file.read_text(encoding='utf-8'))
         self.assertTrue(payload['triggered_for_window'])
 
+    def test_fixed_dream_window_replaces_heartbeat_dispatch(self):
+        temp_root = Path(tempfile.mkdtemp(prefix='agent-manager-fixed-dream-heartbeat-'))
+        work_dir = temp_root / 'workspace'
+        work_dir.mkdir(parents=True, exist_ok=True)
+        (work_dir / 'DREAM.md').write_text('follow dream\n', encoding='utf-8')
+        agent_config = {
+            'name': 'main',
+            'file_id': 'main',
+            'working_directory': str(work_dir),
+            'launcher': 'codex',
+            'heartbeat': {
+                'enabled': True,
+                'cron': '*/10 * * * *',
+                'max_runtime': '8m',
+                'session_mode': 'auto',
+                'schedule': {
+                    'timezone': 'Asia/Shanghai',
+                    'work_days': [1],
+                    'work_hours': {'start': '09:00', 'end': '10:00'},
+                },
+                'dream': {
+                    'enabled': True,
+                    'idle_after': '1h',
+                    'max_runtime': '30m',
+                    'fixed_windows': [
+                        {'timezone': 'Asia/Shanghai', 'start': '23:00', 'end': '08:00'},
+                    ],
+                },
+            },
+            'enabled': True,
+        }
+
+        out = io.StringIO()
+        with redirect_stdout(out), \
+                patch('main.check_tmux', return_value=True), \
+                patch('main.resolve_agent', return_value=agent_config), \
+                patch('main.get_agent_id', return_value='main'), \
+                patch('main.session_exists', return_value=True), \
+                patch('main.resolve_launcher_command', return_value='codex'), \
+                patch('main.get_repo_root', return_value=temp_root), \
+                patch('main._detect_agent_context_left_percent', return_value=None), \
+                patch('main._maybe_rollover_heartbeat_session', return_value=None), \
+                patch('main._maybe_run_main_inbound_heartbeat_sweep', return_value=False), \
+                patch('main.has_pending_inbound_messages', return_value=False), \
+                patch('main._heartbeat_preflight_runtime_state', return_value=('idle', 'ready')), \
+                patch('main.resolve_active_dream_window', return_value={
+                    'active': True,
+                    'window_id': 'fixed-window-1',
+                    'summary': 'Asia/Shanghai 23:00-08:00 Mon-Sun',
+                }), \
+                patch('main._run_heartbeat_attempt') as mock_heartbeat_attempt, \
+                patch('main._run_dream_attempt', return_value={
+                    'send_status': 'ok',
+                    'ack_status': 'ack',
+                    'ack_evidence': 'direct_dream_ok',
+                    'failure_type': '',
+                    'reason_code': 'DREAM_ACK_OK',
+                    'duration_ms': 1000,
+                }) as mock_dream_attempt, \
+                patch('main.cmd_timer') as mock_cmd_timer:
+            rc = main.cmd_heartbeat_run(
+                argparse.Namespace(
+                    agent='main',
+                    timeout=None,
+                    retry=None,
+                    backoff_seconds=None,
+                    fallback_mode=None,
+                    notify_on_failure=False,
+                    notifier_channel=None,
+                )
+            )
+
+        self.assertEqual(rc, 0)
+        mock_heartbeat_attempt.assert_not_called()
+        mock_cmd_timer.assert_not_called()
+        mock_dream_attempt.assert_called_once()
+        self.assertEqual(mock_dream_attempt.call_args.kwargs['timeout_seconds'], 30 * 60)
+        sent_message = mock_dream_attempt.call_args.kwargs['dream_message']
+        self.assertIn('Read DREAM.md', sent_message)
+        self.assertIn('[TRIGGER_HB_ID:', sent_message)
+        self.assertIn('Heartbeat completed via fixed Dream window', out.getvalue())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/agent-manager/scripts/tests/test_dream_window.py
+++ b/agent-manager/scripts/tests/test_dream_window.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from services.dream_window import normalize_dream_fixed_windows, resolve_active_dream_window  # noqa: E402
+
+
+CST = ZoneInfo("Asia/Shanghai")
+
+
+class DreamWindowTests(unittest.TestCase):
+    def test_overnight_fixed_window_is_active_after_midnight(self):
+        dream = {
+            "fixed_windows": [
+                {"timezone": "Asia/Shanghai", "start": "23:00", "end": "08:00"},
+            ],
+        }
+
+        result = resolve_active_dream_window(
+            dream,
+            now=datetime(2026, 5, 6, 2, 0, tzinfo=CST),
+        )
+
+        self.assertTrue(result["active"])
+        self.assertEqual(result["window_id"], "fixed-window-1")
+
+    def test_fixed_windows_default_to_every_day(self):
+        windows = normalize_dream_fixed_windows({
+            "fixed_windows": [{"start": "23:00", "end": "08:00"}],
+        })
+
+        self.assertEqual(windows[0]["work_days"], [1, 2, 3, 4, 5, 6, 7])
+
+    def test_multiple_windows_are_or_rules(self):
+        dream = {
+            "fixed_windows": [
+                {"timezone": "Asia/Shanghai", "start": "23:00", "end": "23:30"},
+                {"timezone": "Asia/Shanghai", "start": "02:00", "end": "03:00"},
+            ],
+        }
+
+        result = resolve_active_dream_window(
+            dream,
+            now=datetime(2026, 5, 6, 2, 15, tzinfo=CST),
+        )
+
+        self.assertTrue(result["active"])
+        self.assertEqual(result["window_id"], "fixed-window-2")
+
+    def test_string_window_shorthand(self):
+        windows = normalize_dream_fixed_windows({
+            "timezone": "Asia/Shanghai",
+            "fixed_windows": ["23:00-08:00"],
+        })
+
+        self.assertEqual(windows[0]["timezone"], "Asia/Shanghai")
+        self.assertEqual(windows[0]["work_hours"], {"start": "23:00", "end": "08:00"})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `heartbeat.dream.fixed_windows` support for fixed Dream periods
- switch heartbeat dispatch to the Dream prompt while any configured fixed window is active
- document the new config shape and show fixed-window count in `heartbeat list`

## Behavior
During an active fixed Dream window, `heartbeat run` sends the standard Dream prompt (`DREAM.md` / `DREAM_OK`) instead of the normal heartbeat prompt (`HEARTBEAT.md` / `HEARTBEAT_OK`). Multiple windows are OR rules, overnight ranges are supported, and omitted `work_days` default to all seven days.

Example:

```yaml
heartbeat:
  dream:
    enabled: true
    max_runtime: 30m
    fixed_windows:
      - timezone: Asia/Shanghai
        start: "13:00"
        end: "13:30"
      - timezone: Asia/Shanghai
        start: "02:00"
        end: "04:00"
```

## Tests
- `python3 -m unittest discover -s scripts/tests` (294 tests)
